### PR TITLE
Fix displaying projects with the same name.

### DIFF
--- a/src/CommerceGuys/Command/PlatformCommand.php
+++ b/src/CommerceGuys/Command/PlatformCommand.php
@@ -162,7 +162,7 @@ class PlatformCommand extends Command
             foreach ($data['projects'] as $project) {
                 $machineName = preg_replace('/[^a-z0-9-]+/i', '-', strtolower($project['name']));
                 $project['machine_name'] = $machineName;
-                $projects[$machineName] = $project;
+                $projects[] = $project;
             }
             $this->config['projects'] = $projects;
         }


### PR DESCRIPTION
I have two platforms with the same name (an empty one).

In the MP they're displayed as 'Platform Dev Environment', I guess that's the default for an empty name.

CLI gives me:

```
+----------+----------+--------------------------------------------+
| ID       | Name     | URL                                        |
+----------+----------+--------------------------------------------+
| frogkind | Frogkind | http://eu1.c-g.io/#/projects/hf4upxxdgrjow |
|          |          | http://eu1.c-g.io/#/projects/st4s5wdczjiio |
| zzzzz    | zzzzz    | http://eu1.c-g.io/#/projects/5zrr6kjlkiw6m |
+----------+----------+--------------------------------------------+
```

One is missing. With this patch:

```
+----------+----------+--------------------------------------------+
| ID       | Name     | URL                                        |
+----------+----------+--------------------------------------------+
| frogkind | Frogkind | http://eu1.c-g.io/#/projects/hf4upxxdgrjow |
|          |          | http://eu1.c-g.io/#/projects/z6llmgxpyzksw |
|          |          | http://eu1.c-g.io/#/projects/st4s5wdczjiio |
| zzzzz    | zzzzz    | http://eu1.c-g.io/#/projects/5zrr6kjlkiw6m |
+----------+----------+--------------------------------------------+
```

I have no idea will this break something else.
