### PR TITLE
Fix installation via Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Now you can run `platform` and see all the available commands !
 
 ## Installation
 ```
-composer global require 'commerceguys/platform-cli:*'
+composer global require commerceguys/guzzle-oauth2-plugin:dev-master commerceguys/platform-cli:dev-master
 ```
 Make sure you have ~/.composer/vendor/bin/ in your path.
 


### PR DESCRIPTION
As you don't have any tagged versions yet, the current command does not work when the global minimum stability of the user is `stable` (which is the default.) So, the only way to get this working for everyone is to force the installation of `dev-master` and install the oauth2 dep first. As soon as you release a stable version, you will be able to simplify the install command.
