### PR TITLE
Make dependency on drush optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is the official CLI for Commerce Platform.
 
 ## Requirements
 
-* Drush 6.0 or higher - https://github.com/drush-ops/drush
 * PHP 5.3.3 or higher with cURL
 * Composer - https://getcomposer.org/doc/00-intro.md
+* Drush 6.0 or higher - https://github.com/drush-ops/drush (only for Drupal projects)
 
 ## Installation (TMP)
 Clone the Git repository locally

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
         "symfony/console": "~2.4",
         "symfony/yaml": "~2.4"
     },
+    "suggest": {
+        "drush/drush": "For Drupal projects"
+    },
     "autoload": {
         "psr-4": {
             "CommerceGuys\\Platform\\Cli\\": "src"

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -17,6 +17,8 @@ class DrushCommand extends PlatformCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->ensureDrushInstalled();
+
         // Try to autodetect the project and environment.
         // There is no point in allowing the user to override them
         // using --project and --environment, in that case they can run

--- a/src/Command/LoginCommand.php
+++ b/src/Command/LoginCommand.php
@@ -38,15 +38,6 @@ class LoginCommand extends PlatformCommand
         if (strpos($gitVersion, 'git version') === false) {
             throw new \Exception('Git must be installed.');
         }
-        $drushVersion = shell_exec('drush version');
-        if (strpos(strtolower($drushVersion), 'drush version') === false) {
-            throw new \Exception('Drush must be installed.');
-        }
-        $versionParts = explode(':', $drushVersion);
-        $versionNumber = trim($versionParts[1]);
-        if (version_compare($versionNumber, '6.0.0') === -1) {
-            throw new \Exception('Drush version must be 6.0.0 or newer.');
-        }
     }
 
     protected function configureAccount($output)

--- a/src/Command/PlatformCommand.php
+++ b/src/Command/PlatformCommand.php
@@ -352,6 +352,19 @@ class PlatformCommand extends Command
         file_put_contents($filename, $export);
     }
 
+    protected function ensureDrushInstalled()
+    {
+        $drushVersion = shell_exec('drush version');
+        if (strpos(strtolower($drushVersion), 'drush version') === false) {
+            throw new \Exception('Drush must be installed.');
+        }
+        $versionParts = explode(':', $drushVersion);
+        $versionNumber = trim($versionParts[1]);
+        if (version_compare($versionNumber, '6.0.0') === -1) {
+            throw new \Exception('Drush version must be 6.0.0 or newer.');
+        }
+    }
+
     /**
      * Destructor: Write the configuration to disk.
      */

--- a/src/Command/ProjectBuildCommand.php
+++ b/src/Command/ProjectBuildCommand.php
@@ -76,6 +76,8 @@ class ProjectBuildCommand extends PlatformCommand
      */
     protected function buildDrupal($buildDir, $projectRoot)
     {
+        $this->ensureDrushInstalled();
+
         $repositoryDir = $projectRoot . '/repository';
         $profiles = glob($repositoryDir . '/*.profile');
         if (count($profiles) > 1) {


### PR DESCRIPTION
The CLI tool forces you to install drush (in the login command), but as far as I can see, this is not required (only needed for some commands related to Drupal).

This PR moves the check for drush only when drush is actually needed (I've also updated composer accordingly).
