### PR TITLE
Allow slashes in branch names.

### DIFF
--- a/src/Command/EnvironmentBranchCommand.php
+++ b/src/Command/EnvironmentBranchCommand.php
@@ -55,7 +55,7 @@ class EnvironmentBranchCommand extends EnvironmentCommand
             $output->writeln("<error>You must specify the name of the new branch.</error>");
             return;
         }
-        $machineName = preg_replace('/[^a-z0-9-]+/i', '', strtolower($branchName));
+        $machineName = preg_replace('/[^a-z0-9-\/]+/i', '', strtolower($branchName));
 
         $client = $this->getPlatformClient($this->environment['endpoint']);
         $client->branchEnvironment(array('name' => $machineName, 'title' => $branchName));


### PR DESCRIPTION
It's a Git Flow convention, so I guess others will want to use slashes.

Although ideally the branch name would be checked according to: https://www.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
