### PR TITLE
Remove the infinite loop in 'login' if there is no STDIN.

### DIFF
--- a/src/Command/LoginCommand.php
+++ b/src/Command/LoginCommand.php
@@ -51,7 +51,7 @@ class LoginCommand extends PlatformCommand
             }
             return $data;
         };
-        $email = $dialog->askAndValidate($output, 'Your email address: ', $emailValidator);
+        $email = $dialog->askAndValidate($output, 'Your email address: ', $emailValidator, 5);
 
         $userExists = true;
         if (!$userExists) {


### PR DESCRIPTION
It left my Jenkins build script running forever.

This PR limits the `askAndValidate()` call using the [`$attempts`](http://api.symfony.com/2.5/Symfony/Component/Console/Helper/DialogHelper.html#method_askAndValidate) parameter.
