### PR TITLE
Remove override of doRun() so the help option works.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -3,15 +3,16 @@
 namespace CommerceGuys\Platform\Cli;
 
 use Symfony\Component\Console;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Shell;
+use Symfony\Component\Console\Output\StreamOutput;
 
 class Application extends Console\Application {
+
+    protected $output;
 
     /**
      * {@inheritdoc}
@@ -21,7 +22,6 @@ class Application extends Console\Application {
         parent::__construct('Platform CLI', '1.1.0');
 
         $this->setDefaultTimezone();
-        $this->getDefinition()->addOption(new InputOption('--shell', '-s', InputOption::VALUE_NONE, 'Launch the shell.'));
 
         $this->toolstacks = array(
             'Php',
@@ -56,6 +56,9 @@ class Application extends Console\Application {
         $this->add(new Command\SshKeyAddCommand);
         $this->add(new Command\SshKeyDeleteCommand);
         $this->add(new Command\SshKeyListCommand);
+        $this->add(new Command\WelcomeCommand);
+
+        $this->setDefaultCommand('welcome');
     }
 
     /**
@@ -66,12 +69,12 @@ class Application extends Console\Application {
         // We remove the confusing `--ansi` and `--no-ansi` options.
         return new InputDefinition(array(
             new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
-
             new InputOption('--help',           '-h', InputOption::VALUE_NONE, 'Display this help message.'),
             new InputOption('--quiet',          '-q', InputOption::VALUE_NONE, 'Do not output any message.'),
             new InputOption('--verbose',        '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version',        '-V', InputOption::VALUE_NONE, 'Display this application version.'),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question.'),
+            new InputOption('--shell', '-s', InputOption::VALUE_NONE, 'Launch the shell.'),
         ));
     }
 
@@ -80,56 +83,19 @@ class Application extends Console\Application {
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        if (true === $input->hasParameterOption(array('--shell', '-s'))) {
-            $shell = new Shell($this);
-            $shell->run();
+        $this->output = $output;
+        return parent::doRun($input, $output);
+    }
 
-            return 0;
+    /**
+     * @return OutputInterface
+     */
+    public function getOutput() {
+        if (isset($this->output)) {
+            return $this->output;
         }
-        if (true === $input->hasParameterOption(array('--version', '-V'))) {
-            $output->writeln($this->getLongVersion());
-
-            return 0;
-        }
-        $name = $this->getCommandName($input);
-        if ($name) {
-            $command = $this->find($name);
-        } else {
-            $command = new Command\WelcomeCommand($this->find('projects'), $this->find('environments'));
-            $command->setApplication($this);
-            $input = new ArrayInput(array('command' => 'welcome'));
-        }
-
-        if (true === $input->hasParameterOption(array('--help', '-h'))) {
-            if (!$name) {
-                $command = $this->find('help');
-                $input = new ArrayInput(array('command' => 'help'));
-            } else {
-                $this->wantHelps = true;
-            }
-        }
-
-        $commandChain = array();
-        // The CLI hasn't been configured, login must run first.
-        if (!$this->hasConfiguration() && (!($command instanceof Command\PlatformCommand) || !$command::skipLogin())) {
-            $this->add(new Command\PlatformLoginCommand);
-            $commandChain[] = array(
-                'command' => $this->find('login'),
-                'input' => new ArrayInput(array('command' => 'login')),
-            );
-        }
-        $commandChain[] = array(
-            'command' => $command,
-            'input' => $input,
-        );
-
-        foreach ($commandChain as $chainData) {
-            $this->runningCommand = $chainData['command'];
-            $exitCode = $this->doRunCommand($chainData['command'], $chainData['input'], $output);
-            $this->runningCommand = null;
-        }
-
-        return $exitCode;
+        $stream = file_open('php://stdout', 'w');
+        return new StreamOutput($stream);
     }
 
     /**

--- a/src/Command/PlatformCommand.php
+++ b/src/Command/PlatformCommand.php
@@ -8,8 +8,7 @@ use CommerceGuys\Guzzle\Plugin\Oauth2\GrantType\RefreshToken;
 use Guzzle\Service\Client;
 use Guzzle\Service\Description\ServiceDescription;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Dumper;
 
@@ -34,11 +33,27 @@ class PlatformCommand extends Command
         if (!$this->config) {
             $application = $this->getApplication();
             $configPath = $application->getHomeDirectory() . '/.platform';
+            if (!file_exists($configPath)) {
+                $this->login();
+            }
             $yaml = new Parser();
             $this->config = $yaml->parse(file_get_contents($configPath));
         }
 
         return $this->config;
+    }
+
+    /**
+     * Log in the user.
+     */
+    protected function login() {
+        $application = $this->getApplication();
+        $command = $application->find('login');
+        $input = new ArrayInput(array('command' => 'login'));
+        $exitCode = $command->run($input, $application->getOutput());
+        if ($exitCode) {
+            throw new \Exception('Login failed');
+        }
     }
 
     /**
@@ -493,11 +508,6 @@ class PlatformCommand extends Command
             }
         }
 
-    }
-
-    public static function skipLogin()
-    {
-        return FALSE;
     }
 
     public function ensureDrushInstalled()

--- a/src/Command/PlatformLoginCommand.php
+++ b/src/Command/PlatformLoginCommand.php
@@ -21,10 +21,6 @@ class PlatformLoginCommand extends PlatformCommand
         return true;
     }
 
-    public static function skipLogin() {
-        return true;
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->checkRequirements($output);

--- a/src/Command/PlatformLogoutCommand.php
+++ b/src/Command/PlatformLogoutCommand.php
@@ -58,11 +58,6 @@ class PlatformLogoutCommand extends PlatformCommand
         }
     }
 
-    public static function skipLogin()
-    {
-        return TRUE;
-    }
-
     /**
      * Destructor: Override the destructor to nuke the config.
      */

--- a/src/Command/ProjectBuildCommand.php
+++ b/src/Command/ProjectBuildCommand.php
@@ -167,11 +167,6 @@ class ProjectBuildCommand extends PlatformCommand
         closedir($sourceDirectory);
     }
 
-    public static function skipLogin()
-    {
-        return TRUE;
-    }
-
     /**
      * Make relative path between two files.
      *

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -8,21 +8,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 class WelcomeCommand extends PlatformCommand
 {
 
-    protected $projectListCommand;
-    protected $environmentListCommand;
-
-    public function __construct($projectListCommand, $environmentListCommand)
-    {
-        $this->projectListCommand = $projectListCommand;
-        $this->environmentListCommand = $environmentListCommand;
-        parent::__construct();
-    }
-
     protected function configure()
     {
         $this
             ->setName('welcome')
             ->setDescription('Welcome to Platform.sh');
+    }
+
+    public function isEnabled() {
+        // Hide the command in the list.
+        global $argv;
+        return !isset($argv[1]) || $argv[1] != 'list';
     }
 
     public function isLocal()
@@ -34,16 +30,18 @@ class WelcomeCommand extends PlatformCommand
     {
         $output->writeln("\nWelcome to Platform.sh!");
 
+        $application = $this->getApplication();
+
         if ($currentProject = $this->getCurrentProject()) {
             // The project is known. Show the environments.
             $projectName = $currentProject['name'];
             $output->write("\nYour project is <info>$projectName</info>.");
-            $this->environmentListCommand->run($input, $output);
+            $application->find('environments')->run($input, $output);
             $output->writeln("You can list other projects by running <info>platform projects</info>.\n");
             $output->writeln("Manage your domains by running <info>platform domains</info>.");
         } else {
             // The project is not known. Show all projects.
-            $this->projectListCommand->run($input, $output);
+            $application->find('projects')->run($input, $output);
         }
 
         $output->writeln("Manage your SSH keys by running <info>platform ssh-keys</info>.");


### PR DESCRIPTION
Fixes #137 

We can't override `doRun()` (nor most \Symfony\Component\Console\Application methods) because of all the private variables.
