### PR TITLE
Project initialize command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ project
   project:clean               Remove project builds.
   project:drush-aliases       Determine and/or recreate the project's Drush aliases (if any).
   project:get                 Does a git clone of the referenced project.
+  project:init                Initialize a project from a cloned Git repository.
 ssh-key
   ssh-key:add                 Add a new SSH key.
   ssh-key:delete              Delete an SSH key.

--- a/src/Application.php
+++ b/src/Application.php
@@ -102,6 +102,7 @@ class Application extends ConsoleApplication {
         $commands[] = new Command\ProjectCleanCommand();
         $commands[] = new Command\ProjectDrushAliasesCommand();
         $commands[] = new Command\ProjectGetCommand();
+        $commands[] = new Command\ProjectInitCommand();
         $commands[] = new Command\SshKeyAddCommand();
         $commands[] = new Command\SshKeyDeleteCommand();
         $commands[] = new Command\SshKeyListCommand();

--- a/src/Command/PlatformLoginCommand.php
+++ b/src/Command/PlatformLoginCommand.php
@@ -44,9 +44,7 @@ class PlatformLoginCommand extends PlatformCommand
         if (ini_get('safe_mode')) {
             throw new \Exception('PHP safe_mode must be disabled.');
         }
-        if (!$this->getHelper('shell')->execute(array('git', '--version'))) {
-            throw new \Exception('Git must be installed.');
-        }
+        $this->getHelper('git')->ensureInstalled();
     }
 
     protected function configureAccount(InputInterface $input, OutputInterface $output)

--- a/src/Command/ProjectGetCommand.php
+++ b/src/Command/ProjectGetCommand.php
@@ -2,13 +2,13 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use CommerceGuys\Platform\Cli\Local\LocalProject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Yaml\Dumper;
 
 class ProjectGetCommand extends PlatformCommand
 {
@@ -98,24 +98,17 @@ class ProjectGetCommand extends PlatformCommand
             $environment = 'master';
         }
 
-        // Create the directory structure
+        // Create the directory structure.
         mkdir($directoryName);
         $projectRoot = realpath($directoryName);
+        $local = new LocalProject();
         if (!$projectRoot) {
            throw new \Exception('Failed to create project directory: ' . $directoryName);
         }
 
-        mkdir($projectRoot . '/builds');
-        mkdir($projectRoot . '/shared');
+        $local->createProjectFiles($projectRoot, $projectId);
 
         $fsHelper = $this->getHelper('fs');
-
-        // Create the .platform-project file.
-        $projectConfig = array(
-            'id' => $projectId,
-        );
-        $dumper = new Dumper();
-        file_put_contents($directoryName . '/.platform-project', $dumper->dump($projectConfig));
 
         // Prepare to talk to the Platform.sh repository.
         $projectUriParts = explode('/', str_replace(array('http://', 'https://'), '', $project['uri']));

--- a/src/Command/ProjectInitCommand.php
+++ b/src/Command/ProjectInitCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CommerceGuys\Platform\Cli\Command;
+
+use CommerceGuys\Platform\Cli\Local\LocalProject;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProjectInitCommand extends PlatformCommand
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('project:init')
+            ->setAliases(array('init'))
+            ->addArgument('directory', InputArgument::OPTIONAL, 'The path to the repository.')
+            ->setDescription('Initialize a project from a cloned Git repository.');
+    }
+
+    public function isLocal()
+    {
+        return true;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $directory = $input->getArgument('directory') ?: getcwd();
+        $realPath = realpath($directory);
+        if (!$realPath) {
+            $output->writeln("<error>Directory not found: $directory</error>");
+            return 1;
+        }
+
+        $inside = strpos(getcwd(), $realPath) === 0;
+
+        $local = new LocalProject();
+        $projectRoot = $local->initialize($directory);
+
+        $output->writeln("Project initialized in directory: <info>$projectRoot</info>");
+
+        if ($inside) {
+            $output->writeln("<comment>Type 'cd .' to refresh your shell</comment>");
+        }
+
+        return 0;
+    }
+
+}

--- a/src/Helper/DrushHelper.php
+++ b/src/Helper/DrushHelper.php
@@ -33,6 +33,10 @@ class DrushHelper extends Helper {
      */
     public function ensureInstalled($minVersion = '6')
     {
+        static $checked;
+        if ($checked) {
+            return true;
+        }
         $drushVersion = $this->execute(array('--version'));
         if (!is_string($drushVersion)) {
             throw new \Exception('Drush must be installed');
@@ -42,6 +46,7 @@ class DrushHelper extends Helper {
         if (version_compare($versionNumber, $minVersion) === -1) {
             throw new \Exception('Drush version must be at least: ' . $minVersion);
         }
+        $checked = true;
     }
 
     /**

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -34,6 +34,22 @@ class GitHelper extends Helper
     }
 
     /**
+     * @throws \Exception
+     */
+    public function ensureInstalled()
+    {
+        static $checked;
+        if ($checked) {
+            return true;
+        }
+        $version = $this->execute(array('--version'));
+        if (!is_string($version)) {
+            throw new \Exception('Git must be installed');
+        }
+        $checked = true;
+    }
+
+    /**
      * @return ShellHelperInterface
      */
     protected function getShellHelper()

--- a/src/Local/LocalProject.php
+++ b/src/Local/LocalProject.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace CommerceGuys\Platform\Cli\Local;
+
+use CommerceGuys\Platform\Cli\Helper\GitHelper;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Dumper;
+
+class LocalProject
+{
+
+    /**
+     * Create the default files for a project.
+     *
+     * @param string $projectRoot
+     * @param string $projectId
+     */
+    public function createProjectFiles($projectRoot, $projectId)
+    {
+        mkdir($projectRoot . '/builds');
+        mkdir($projectRoot . '/shared');
+
+        // Create the .platform-project file.
+        $projectConfig = array(
+          'id' => $projectId,
+        );
+        $dumper = new Dumper();
+        file_put_contents($projectRoot . '/.platform-project', $dumper->dump($projectConfig));
+    }
+
+    /**
+     * Initialize a project in a directory.
+     *
+     * @param string $dir
+     *
+     * @throws \RuntimeException
+     *
+     * @return string The absolute path to the project.
+     */
+    public function initialize($dir) {
+        $realPath = realpath($dir);
+        if (!$realPath) {
+            throw new \RuntimeException("Directory not readable: $dir");
+        }
+
+        $dir = $realPath;
+
+        if (file_exists("$dir/../.platform-project")) {
+            throw new \RuntimeException("The project is already initialized");
+        }
+
+        // Get the project ID from the Git repository.
+        $projectId = $this->getProjectIdFromGit($dir);
+
+        // Move the directory into a 'repository' subdirectory.
+        $backupDir = $this->getBackupDir($dir);
+
+        $fs = new Filesystem();
+        $fs->rename($dir, $backupDir);
+        $fs->mkdir($dir, 0755);
+        $fs->rename($backupDir, "$dir/repository");
+
+        $this->createProjectFiles($dir, $projectId);
+
+        return $dir;
+    }
+
+    /**
+     * @param string $dir
+     *
+     * @throws \RuntimeException
+     *   If the directory is not a clone of a Platform.sh Git repository.
+     *
+     * @return string|false
+     *   The project ID, or false if it cannot be determined.
+     */
+    protected function getProjectIdFromGit($dir)
+    {
+        if (!file_exists("$dir/.git")) {
+            throw new \RuntimeException('The directory is not a Git repository');
+        }
+        $gitHelper = new GitHelper();
+        $gitHelper->ensureInstalled();
+        $originUrl = $gitHelper->getConfig("remote.origin.url", $dir);
+        if (!$originUrl) {
+            throw new \RuntimeException("Git remote 'origin' not found");
+        }
+        if (!preg_match('/^([a-z][a-z0-9]{12})@git\.[a-z\-]+\.platform\.sh:\1\.git$/', $originUrl, $matches)) {
+            throw new \RuntimeException("The Git remote 'origin' is not a Platform.sh URL");
+        }
+        return $matches[1];
+    }
+
+    /**
+     * Get a backup name for a directory.
+     *
+     * @param $dir
+     * @param int $inc
+     *
+     * @return string
+     */
+    protected function getBackupDir($dir, $inc = 0)
+    {
+        $backupDir = $dir . '-backup';
+        $backupDir .= $inc ?: '';
+        if (file_exists($backupDir)) {
+            return $this->getBackupDir($dir, ++$inc);
+        }
+        return $backupDir;
+    }
+
+}


### PR DESCRIPTION
This may be useful if you directly cloned a Platform.sh repository (and perhaps started work).

It is possible to run the command from inside the repository directory, but it leaves the shell in a weird state, at least when using ZSH (it reports the wrong cwd). I don't know of a way (from PHP) to `cd` on behalf of the user. So this warns you:

> Project initialized in directory: /absolute/path/to/projectRoot
> Type 'cd .' to refresh your shell
