### PR TITLE
Improve projects/environments refresh experience.

### DIFF
--- a/src/Command/EnvironmentListCommand.php
+++ b/src/Command/EnvironmentListCommand.php
@@ -46,8 +46,9 @@ class EnvironmentListCommand extends EnvironmentCommand
             ->addOption(
                 'refresh',
                 null,
-                InputOption::VALUE_NONE,
-                'Refresh the list.'
+                InputOption::VALUE_OPTIONAL,
+                'Whether to refresh the list.',
+                1
             );
     }
 

--- a/src/Command/ProjectListCommand.php
+++ b/src/Command/ProjectListCommand.php
@@ -4,6 +4,7 @@ namespace CommerceGuys\Platform\Cli\Command;
 
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ProjectListCommand extends PlatformCommand
@@ -13,12 +14,33 @@ class ProjectListCommand extends PlatformCommand
     {
         $this
             ->setName('projects')
-            ->setDescription('Get a list of all active projects.');
+            ->setDescription('Get a list of all active projects.')
+            ->addOption(
+              'pipe',
+              null,
+              InputOption::VALUE_NONE,
+              'Output a simple list of project IDs.'
+            )
+            ->addOption(
+              'refresh',
+              null,
+              InputOption::VALUE_OPTIONAL,
+              'Whether to refresh the list.',
+              1
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $projects = $this->getProjects(true);
+        $refresh = $input->hasOption('refresh') && $input->getOption('refresh');
+
+        $projects = $this->getProjects($refresh);
+
+        if ($input->getOption('pipe') || !$this->isTerminal($output)) {
+            $output->writeln(array_keys($projects));
+            return 0;
+        }
+
         $rows = array();
         foreach ($projects as $projectId => $project) {
             $row = array();

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -2,6 +2,7 @@
 
 namespace CommerceGuys\Platform\Cli\Command;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -28,20 +29,28 @@ class WelcomeCommand extends PlatformCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->writeln("Welcome to Platform.sh!\n");
+        $output->writeln("Welcome to Platform.sh!");
 
         $application = $this->getApplication();
 
         if ($currentProject = $this->getCurrentProject()) {
             // The project is known. Show the environments.
             $projectName = $currentProject['name'];
-            $output->writeln("Your project is <info>$projectName</info>.\n");
-            $application->find('environments')->run($input, $output);
+            $output->writeln("\nYour project is <info>$projectName</info>.\n");
+            $envInput = new ArrayInput(array(
+                'command' => 'environments',
+                '--refresh' => 0,
+              ));
+            $application->find('environments')->run($envInput, $output);
             $output->writeln("\nYou can list other projects by running <info>platform projects</info>.\n");
             $output->writeln("Manage your domains by running <info>platform domains</info>.");
         } else {
             // The project is not known. Show all projects.
-            $application->find('projects')->run($input, $output);
+            $projectsInput = new ArrayInput(array(
+                'command' => 'projects',
+                '--refresh' => 0,
+              ));
+            $application->find('projects')->run($projectsInput, $output);
         }
 
         $output->writeln("Manage your SSH keys by running <info>platform ssh-keys</info>.");


### PR DESCRIPTION
- `platform projects` refreshes by default (use --refresh=0 to disable)
- `platform environments` refreshes by default (use --refresh=0 to disable)
- `platform` (welcome command) only refreshes each if the list is empty
