### PR TITLE
Auto add to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,11 @@ The **Platform.sh CLI** is the official command-line interface for [Platform.sh]
 
         composer global require 'platformsh/cli:1.*'
 
-* Make sure Composer's `vendor/bin` directory is in your system's PATH.
+* Add this line to your [shell configuration file](#shell-configuration-file):
 
-  In Linux or OS X, add this line to your [shell configuration file](#shell-configuration-file):
-
-        export PATH="$PATH:~/.composer/vendor/bin"
-
-  In Windows, use this command from a Command Prompt (cmd.exe):
-
-        setx PATH "%PATH%;%APPDATA%\Composer\vendor\bin"
+        . ~/.composer/vendor/platformsh/cli/platform.rc 2>/dev/null
 
   Start a new shell before continuing.
-
-* Optionally, enable auto-completion. Add these lines to your [shell
-  configuration file](#shell-configuration-file):
-
-        # Platform.sh CLI configuration
-        PLATFORMSH_CONF=~/.composer/vendor/platformsh/cli/platform.rc
-        [ -f "$PLATFORMSH_CONF" ] && . "$PLATFORMSH_CONF"
 
 #### Shell configuration file
 Your 'shell configuration file' might be in any of the following

--- a/bin/platform
+++ b/bin/platform
@@ -9,7 +9,7 @@ define('CLI_VERIFY_SSL_CERT', (bool) !getenv("PLATFORM_CLI_SKIP_SSL_VERIFY"));
 
 // __DIR__ called in a class will point to the class directory. Saved now it
 // ensure there's always a path to the cli root.
-define('CLI_ROOT', __DIR__);
+define('CLI_ROOT', dirname(__DIR__));
 
 if (file_exists(CLI_ROOT . '/vendor/autoload.php')) {
     require CLI_ROOT . '/vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         }
     ],
     "bin": [
-        "platform"
+        "bin/platform"
     ]
 }

--- a/platform.rc
+++ b/platform.rc
@@ -1,9 +1,46 @@
 #!/usr/bin/env bash
 # Platform.sh CLI shell configuration.
+#
+# This file is intended to be sourced from the user's shell.
+
+# Get the full path to this installation.
+SOURCE=$0
+[ ! -z "$BASH_SOURCE" ] && SOURCE=${BASH_SOURCE[0]}
+INSTALL_DIR=$(cd "$(dirname -- "${SOURCE}")" && pwd)
+
+# Get the path to the directory containing the 'platform' executable.
+BIN_DIR=${INSTALL_DIR}/bin
+# If installed via Composer, the BIN_DIR is Composer's vendor/bin directory.
+if [ "$(basename ${INSTALL_DIR})" = 'cli' ] && [ -d "${INSTALL_DIR}/../../bin" ]; then
+    BIN_DIR=$(cd "${INSTALL_DIR}/../../bin" && pwd)
+fi
+
+# Add the BIN_DIR to the PATH, if it isn't there already.
+if [ -f "${BIN_DIR}/platform" ] && [[ ! ":$PATH:" == *:${BIN_DIR}:* ]]; then
+    export PATH="$BIN_DIR:$PATH"
+fi
 
 # Enable auto-completion.
-HOOK=$(platform _completion -g -p platform)
-# Try two commands.
-# See https://github.com/stecman/symfony-console-completion/issues/12
-echo "$HOOK" | source /dev/stdin
-source <(echo "$HOOK") 2>/dev/null
+SHELL_TYPE=''
+# Bash autocompletion requires the _get_comp_words_by_ref function.
+if command -v _get_comp_words_by_ref > /dev/null; then
+    # Specify an explicit shell type if the function exists (so we are
+    # using Bash) yet $SHELL was not defined.
+    [ -z "$SHELL" ] && SHELL_TYPE=bash
+elif [[ "$SHELL" == *bash ]]; then
+    # Fail if the shell is Bash, yet the function does not exist.
+    return
+fi
+
+HOOK=$("${BIN_DIR}/platform" _completion -g -p platform --shell-type=${SHELL_TYPE} 2>/dev/null)
+[ -z "$HOOK" ] && return
+
+# Try three methods of registering autocompletion.
+# See https://github.com/stecman/symfony-console-completion#zero-config-use
+if [[ "${BASH_VERSION}" == 4* ]]; then
+    source <(echo ${HOOK})
+elif [ ! -z "${BASH_VERSION}" ]; then
+    eval "${HOOK}"
+elif [ ! -z "$ZSH" ]; then
+    echo "${HOOK}" | source /dev/stdin
+fi


### PR DESCRIPTION
Pros:
1. Removes an install step
2. Easier BC if we want to change where the CLI is installed (e.g. see this [installer](/pjcdawkins/platformsh-cli-installer))
3. Appears to work on Windows, so this unifies the configuration a bit

Cons:
1. My bash might be a bit ropey (?)
2. I moved the executable file (I don't think that's a BC break though as the proper installation method is via Composer)
3. Might not actually work on Windows
