### PR TITLE
Fix performance regression with many environments and Drush aliases

### DIFF
--- a/src/Command/Local/LocalDrushAliasesCommand.php
+++ b/src/Command/Local/LocalDrushAliasesCommand.php
@@ -106,6 +106,14 @@ class LocalDrushAliasesCommand extends CommandBase
             /** @var \Platformsh\Cli\Service\RemoteEnvVars $envVarsService */
             $envVarsService = $this->getService('remote_env_vars');
             foreach ($environments as $environment) {
+
+                // Cache the environment's deployment information.
+                // This will at least be used for \Platformsh\Cli\Service\Drush::getSiteUrl().
+                if (!$this->api()->hasCachedCurrentDeployment($environment) && $environment->isActive()) {
+                    $this->debug('Fetching deployment information for environment: ' . $environment->id);
+                    $this->api()->getCurrentDeployment($environment);
+                }
+
                 if ($environment->deployment_target === 'local') {
                     continue;
                 }

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -782,6 +782,20 @@ class Api
     }
 
     /**
+     * Returns whether the current deployment for an environment is already cached.
+     *
+     * @param Environment $environment
+     *
+     * @return bool
+     */
+    public function hasCachedCurrentDeployment(Environment $environment)
+    {
+        $cacheKey = implode(':', ['current-deployment', $environment->project, $environment->id, $environment->head_commit]);
+
+        return $this->cache->contains($cacheKey);
+    }
+
+    /**
      * Get the default environment in a list.
      *
      * @param array $environments An array of environments, keyed by ID.

--- a/src/Service/Drush.php
+++ b/src/Service/Drush.php
@@ -373,7 +373,16 @@ class Drush
      */
     public function getSiteUrl(Environment $environment, LocalApplication $app)
     {
-        return $this->api->getSiteUrl($environment, $app->getName());
+        if ($this->api->hasCachedCurrentDeployment($environment)) {
+            return $this->api->getSiteUrl($environment, $app->getName());
+        }
+
+        $urls = $environment->getRouteUrls();
+        if (count($urls) === 1) {
+            return reset($urls) ?: null;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Drush aliases now depend on the deployments API for the site URL. However,
fetching this information for every environment, whenever the environments list
is refreshed, is very slow for projects with many environments.

This commit ensures that while "drush-aliases --recreate" will fetch the
deployment for every environment, other commands will not.