### PR TITLE
Ask fewer questions in project:create and variable:create forms

### DIFF
--- a/src/Command/Project/ProjectCreateCommand.php
+++ b/src/Command/Project/ProjectCreateCommand.php
@@ -403,6 +403,7 @@ EOF
             },
             'default' => in_array('development', $this->getAvailablePlans(false, $setupOptions)) ? 'development' : null,
             'allowOther' => true,
+            'avoidQuestion' => true,
           ]),
           'environments' => new Field('Environments', [
             'optionName' => 'environments',
@@ -411,6 +412,7 @@ EOF
             'validator' => function ($value) {
                 return is_numeric($value) && $value > 0 && $value < 50;
             },
+            'avoidQuestion' => true,
           ]),
           'storage' => new Field('Storage', [
             'description' => 'The amount of storage per environment, in GiB',
@@ -418,6 +420,7 @@ EOF
             'validator' => function ($value) {
                 return is_numeric($value) && $value > 0 && $value < 1024;
             },
+            'avoidQuestion' => true,
           ]),
           'default_branch' => new Field('Default branch', [
             'description' => 'The default Git branch name for the project (the production environment)',

--- a/src/Command/Variable/VariableCommandBase.php
+++ b/src/Command/Variable/VariableCommandBase.php
@@ -195,14 +195,16 @@ abstract class VariableCommandBase extends CommandBase
             'description' => "The variable's value",
         ]);
         $fields['is_json'] = new BooleanField('JSON', [
-            'description' => 'Whether the variable is JSON-formatted',
-            'questionLine' => 'Is the value JSON-formatted',
+            'description' => 'Whether the variable value is JSON-formatted',
+            'questionLine' => 'Is the value JSON-formatted?',
             'default' => false,
+            'avoidQuestion' => true,
         ]);
         $fields['is_sensitive'] = new BooleanField('Sensitive', [
-            'description' => 'Whether the variable is sensitive',
+            'description' => 'Whether the variable value is sensitive',
             'questionLine' => 'Is the value sensitive?',
             'default' => false,
+            'avoidQuestion' => true,
         ]);
         $fields['prefix'] = new OptionsField('Prefix', [
             'description' => "The variable name's prefix",
@@ -225,6 +227,7 @@ abstract class VariableCommandBase extends CommandBase
             ],
             'description' => 'Whether the variable should be enabled',
             'questionLine' => 'Should the variable be enabled?',
+            'avoidQuestion' => true,
         ]);
         $fields['is_inheritable'] = new BooleanField('Inheritable', [
             'conditions' => [
@@ -232,6 +235,7 @@ abstract class VariableCommandBase extends CommandBase
             ],
             'description' => 'Whether the variable is inheritable by child environments',
             'questionLine' => 'Is the variable inheritable (by child environments)?',
+            'avoidQuestion' => true,
         ]);
         $fields['visible_build'] = new BooleanField('Visible at build time', [
             'optionName' => 'visible-build',
@@ -243,11 +247,13 @@ abstract class VariableCommandBase extends CommandBase
                 // This defaults to true for project-level variables, false otherwise.
                 return isset($values['level']) && $values['level'] === self::LEVEL_PROJECT;
             },
+            'avoidQuestion' => true,
         ]);
         $fields['visible_runtime'] = new BooleanField('Visible at runtime', [
             'optionName' => 'visible-runtime',
             'description' => 'Whether the variable should be visible at runtime',
             'questionLine' => 'Should the variable be available at runtime?',
+            'avoidQuestion' => true,
         ]);
 
         return $fields;


### PR DESCRIPTION
Relates to #1002 

Some optional questions will be omitted. The options are still available on the
command-line, and are not deprecated, but will no longer be asked in interactive
mode. These are:
    
* the --plan, --environments and --storage in the project:create command
* --json, --sensitive, --enabled, --prefix, --inheritable, --visible-build, and
      --visible-runtime in the variable:create command
