### PR TITLE
Exclude unnecessary libphonenumber data from Phar build

### DIFF
--- a/box.json
+++ b/box.json
@@ -23,7 +23,10 @@
       "exclude": [
         "phpunit",
         "Tests",
-        "tests"
+        "tests",
+        "giggsey/libphonenumber-for-php/src/carrier/data",
+        "giggsey/libphonenumber-for-php/src/geocoding/data",
+        "giggsey/locale/data"
       ]
     }
   ],


### PR DESCRIPTION
Roughly 20MB -> 5MB