### PR TITLE
Fix RecursiveDirectoryIterator UnexpectedValueException

### DIFF
--- a/src/Command/Environment/EnvironmentDrushCommand.php
+++ b/src/Command/Environment/EnvironmentDrushCommand.php
@@ -34,8 +34,9 @@ class EnvironmentDrushCommand extends CommandBase
     public function isHidden()
     {
         // Hide this command in the list if the project is not Drupal.
+        // Avoid checking if running in the home directory.
         $projectRoot = $this->getProjectRoot();
-        if ($projectRoot && !Drupal::isDrupal($projectRoot)) {
+        if ($projectRoot && $this->config()->getHomeDirectory() !== getcwd() && !Drupal::isDrupal($projectRoot)) {
             return true;
         }
 

--- a/src/Command/Local/LocalDrushAliasesCommand.php
+++ b/src/Command/Local/LocalDrushAliasesCommand.php
@@ -32,8 +32,9 @@ class LocalDrushAliasesCommand extends CommandBase
     public function isHidden()
     {
         // Hide this command in the list if the project is not Drupal.
+        // Avoid checking if running in the home directory.
         $projectRoot = $this->getProjectRoot();
-        if ($projectRoot && !Drupal::isDrupal($projectRoot)) {
+        if ($projectRoot && $this->config()->getHomeDirectory() !== getcwd() && !Drupal::isDrupal($projectRoot)) {
             return true;
         }
 

--- a/src/Local/BuildFlavor/Drupal.php
+++ b/src/Local/BuildFlavor/Drupal.php
@@ -38,6 +38,7 @@ class Drupal extends BuildFlavorBase
         // Look for at least one Drush make file.
         $finder->in($directory)
                ->files()
+               ->ignoreUnreadableDirs()
                ->depth($depth)
                ->exclude(['node_modules', 'vendor'])
                ->name('project.make*')
@@ -50,6 +51,7 @@ class Drupal extends BuildFlavorBase
         // contain the word "Drupal".
         $finder->in($directory)
                ->files()
+               ->ignoreUnreadableDirs()
                ->depth($depth)
                ->name('index.php');
         foreach ($finder as $file) {
@@ -64,6 +66,7 @@ class Drupal extends BuildFlavorBase
         // Check whether there is a composer.json file requiring Drupal core.
         $finder->in($directory)
                ->files()
+               ->ignoreUnreadableDirs()
                ->depth($depth)
                ->name('composer.json');
         foreach ($finder as $file) {


### PR DESCRIPTION
This seems to occur when the home directory is recognised as a project, and isDrupal is running unnecessarily. This commit avoids performing the check unnecessarily while in the home directory, and sets Symfony to ignore unreadable directories while iterating.