### PR TITLE
Allow base URLs for GitHub integration

### DIFF
--- a/src/Command/Integration/IntegrationCommandBase.php
+++ b/src/Command/Integration/IntegrationCommandBase.php
@@ -207,6 +207,7 @@ abstract class IntegrationCommandBase extends CommandBase
             ]),
             'base_url' => new UrlField('Base URL', [
                 'conditions' => ['type' => [
+                    'github',
                     'gitlab',
                     'bitbucket_server',
                 ]],


### PR DESCRIPTION
Based on the [API](https://api.platform.sh/docs/#tag/Third-Party-Integrations/operation/create-projects-integrations) and the Console, it's possible to add a base URL for GitHub integrations, but the CLI seemed to restrict it. Adding it as possible for GitHub integrations.