### PR TITLE
Provide more ways to suppress the legacy warning

### DIFF
--- a/dist/installer.php
+++ b/dist/installer.php
@@ -122,7 +122,7 @@ class Installer {
 
         $this->output($this->cliName . " installer", 'heading');
 
-        if ($this->migratePrompt && !$this->isCI() && !getenv('NO_LEGACY_WARNING') && !$this->flagEnabled('no-legacy-warning')) {
+        if ($this->migratePrompt && !$this->isCI() && !getenv($this->envPrefix . 'NO_LEGACY_WARNING') && !$this->flagEnabled('no-legacy-warning')) {
             $this->output('');
             $this->output('Warning', 'heading');
             $this->output('This is the "legacy" PHP-based installer and is no longer recommended.');
@@ -132,7 +132,7 @@ class Installer {
             }
             $this->output('');
             $this->output('To suppress this message, set the environment variable ', null, false);
-            $this->output('NO_LEGACY_WARNING=1', 'info');
+            $this->output($this->envPrefix . 'NO_LEGACY_WARNING=1', 'info');
             if ($this->isInteractive() && $this->isTerminal(STDERR)) {
                 $this->output('');
                 $waitTime = 10;

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -989,15 +989,17 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     }
 
     /**
-     * Detects if it's running within a CI.
+     * Detects if running within a CI or local container system.
      *
      * @return bool
      */
-    protected function isCI()
+    private function isCI()
     {
-        return getenv('CI') // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
-            || getenv('BUILD_NUMBER') // Jenkins, TeamCity
-            || getenv('RUN_ID') // TaskCluster, dsari
+        return getenv('CI') !== false // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+            || getenv('BUILD_NUMBER') !== false // Jenkins, TeamCity
+            || getenv('RUN_ID') !== false // TaskCluster, dsari
+            || getenv('LANDO_INFO') !== false // Lando (https://docs.lando.dev/guides/lando-info.html)
+            || getenv('IS_DDEV_PROJECT') === 'true' // DDEV (https://ddev.readthedocs.io/en/latest/users/extend/custom-commands/#environment-variables-provided)
             || $this->detectRunningInHook(); // PSH
     }
 

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -352,6 +352,11 @@ class Config
         if (($value = $this->getEnv('SSH_DOMAIN_WILDCARD')) !== false) {
             $this->config['api']['ssh_domain_wildcards'] = [$value];
         }
+
+        // Special case: {PREFIX}NO_LEGACY_WARNING disables the migration prompt.
+        if ($this->getEnv('NO_LEGACY_WARNING')) {
+            $this->config['migrate']['prompt'] = false;
+        }
     }
 
     /**


### PR DESCRIPTION
Reads the following environment variables to suppress the warning about migrating to the new CLI installation method:
- PLATFORMSH_CLI_NO_LEGACY_WARNING=1
- IS_DDEV_PROJECT=true
- LANDO_INFO=anything

(in addition to the other currently supported variables which are `CI`, `BUILD_NUMBER` and `RUN_ID`)

Also accepts a command-line option `--no-legacy-warning`, e.g.

```sh
curl url/to/installer.php | php -- --no-legacy-warning
```
