### PR TITLE
Fix help command to properly display executable

### DIFF
--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -10,12 +10,13 @@ use Platformsh\Cli\Service\Config;
 use Platformsh\Cli\Console\CustomMarkdownDescriptor;
 use Platformsh\Cli\Console\CustomTextDescriptor;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\HelpCommand as ParentHelpCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class HelpCommand extends ParentHelpCommand
+class HelpCommand extends CommandBase
 {
 
     protected $command;
@@ -26,6 +27,36 @@ class HelpCommand extends ParentHelpCommand
     public function setCommand(Command $command)
     {
         $this->command = $command;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->ignoreValidationErrors();
+
+        $this
+            ->setName('help')
+            ->setDefinition([
+                new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', 'help'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
+                new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw command help'),
+            ])
+            ->setDescription('Displays help for a command')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command displays help for a given command:
+
+  <info>%command.full_name% list</info>
+
+You can also output the help in other formats by using the <comment>--format</comment> option:
+
+  <info>%command.full_name% --format=xml list</info>
+
+To display the list of available commands, please use the <info>list</info> command.
+EOF
+            )
+        ;
     }
 
     /**


### PR DESCRIPTION
The help command did not extend CommandBase and thus the executable name was not interpolated correctly. Copied the help command over from the base help command to be the same, but extended from CommandBase for correct interpolation