### PR TITLE
Suppress deprecation notices by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Other customization is available via environment variables:
 * `PLATFORMSH_CLI_TOKEN`: an API token. *_Warning_*: An API token can act as the account that created it, with no restrictions. Use a separate machine account to limit the token's access. Additionally, storing a secret in an environment variable can be insecure. It may be better to use the `auth:api-token-login` command. The environment variable is preferable on CI systems like Jenkins and GitLab.
 * `PLATFORMSH_CLI_UPDATES_CHECK`: set to 0 to disable the automatic updates check
 * `PLATFORMSH_CLI_AUTO_LOAD_SSH_CERT`: set to 0 to disable automatic loading of an SSH certificate when running login or SSH commands
+* `PLATFORMSH_CLI_REPORT_DEPRECATIONS`: set to 1 to enable PHP deprecation notices (suppressed by default). They will only be displayed in debug mode (`-vvv`).
 * `CLICOLOR_FORCE`: set to 1 or 0 to force colorized output on or off, respectively
 * `http_proxy` or `https_proxy`: specify a proxy for connecting to Platform.sh
 

--- a/bin/platform
+++ b/bin/platform
@@ -12,8 +12,7 @@ ini_set('display_errors', 'stderr');
 ini_set('log_errors', '0');
 
 // Disable early deprecation notices, e.g. those relating to Symfony Console.
-// Deprecation-level notices may be switched back on inside the application, or with the CLI_DEBUG environment variable.
-error_reporting(getenv('CLI_DEBUG') ? E_ALL : E_ALL & ~E_DEPRECATED);
+error_reporting(E_ALL & ~E_DEPRECATED);
 
 if (version_compare(PHP_VERSION, '5.5.9', '<')) {
     printf("This tool requires at least PHP 5.5.9. You currently have %s installed. Please upgrade your PHP version.\n", PHP_VERSION);


### PR DESCRIPTION
Fixing deprecation notices isn't going to happen in v4 because it would break compatibility with older versions of PHP. These notices are not helpful for non-maintainers. This PR suppresses deprecation notices unless:

- debug mode is enabled (with `-vvv`), and
- an environment variable is set: `PLATFORMSH_CLI_REPORT_DEPRECATIONS=1`