### PR TITLE
Describe environments more concisely by default

### DIFF
--- a/src/Command/Backup/BackupRestoreCommand.php
+++ b/src/Command/Backup/BackupRestoreCommand.php
@@ -94,7 +94,7 @@ class BackupRestoreCommand extends CommandBase
             ? $this->api()->getEnvironment($target, $this->getSelectedProject())
             : $environment;
         $targetLabel = $targetEnvironment
-            ? $this->api()->getEnvironmentLabel($targetEnvironment)
+            ? $this->api()->getEnvironmentLabel($targetEnvironment, 'info', true)
             : '<info>' . $target . '</info>';
 
         // Do not allow restoring with --target on legacy regions: it can

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -757,7 +757,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             && !empty($config['mapping'][$currentBranch])) {
             $environment = $this->api()->getEnvironment($config['mapping'][$currentBranch], $project, $refresh);
             if ($environment) {
-                $this->debug('Found mapped environment for branch "' . $currentBranch . '": ' . $this->api()->getEnvironmentLabel($environment));
+                $this->debug('Found mapped environment for branch "' . $currentBranch . '": ' . $this->api()->getEnvironmentLabel($environment, 'info', true));
                 return $environment;
             } else {
                 unset($config['mapping'][$currentBranch]);
@@ -1180,7 +1180,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             $environments = $this->api()->getEnvironments($this->project);
             $environment = $this->api()->getDefaultEnvironment($environments, $this->project);
             if ($environment) {
-                $this->stdErr->writeln(\sprintf('Selected default environment: %s', $this->api()->getEnvironmentLabel($environment)));
+                $this->stdErr->writeln(\sprintf('Selected default environment: %s', $this->api()->getEnvironmentLabel($environment, 'info', true)));
                 $this->printedSelectedEnvironment = true;
                 $this->environment = $environment;
                 return;
@@ -1519,7 +1519,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         } else {
             $environmentList = [];
             foreach ($environments as $environment) {
-                $environmentList[$environment->id] = $this->api()->getEnvironmentLabel($environment, false);
+                $environmentList[$environment->id] = $this->api()->getEnvironmentLabel($environment, false, true);
             }
             asort($environmentList, SORT_NATURAL | SORT_FLAG_CASE);
 
@@ -1665,7 +1665,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
                 return;
             }
             $this->ensurePrintSelectedProject();
-            $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->environment));
+            $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->environment, 'info', true));
             $this->printedSelectedEnvironment = true;
             if ($blankLine) {
                 $this->stdErr->writeln('');

--- a/src/Command/Environment/EnvironmentDeleteCommand.php
+++ b/src/Command/Environment/EnvironmentDeleteCommand.php
@@ -147,7 +147,7 @@ EOF
         if (!$anythingSpecified
             && empty($selectedEnvironments)
             && ($current = $this->getCurrentEnvironment($this->getSelectedProject()))) {
-            $this->stdErr->writeln('Nothing specified; selecting the current environment: '. $this->api()->getEnvironmentLabel($current));
+            $this->stdErr->writeln('Nothing specified; selecting the current environment: '. $this->api()->getEnvironmentLabel($current, 'info', true));
             $this->stdErr->writeln('');
             $selectedEnvironments[$current->id] = $current;
         }

--- a/src/Command/WelcomeCommand.php
+++ b/src/Command/WelcomeCommand.php
@@ -122,7 +122,7 @@ class WelcomeCommand extends CommandBase
         if ($project) {
             $this->stdErr->writeln('Project: ' . $this->api()->getProjectLabel($project));
             if ($environment) {
-                $this->stdErr->writeln('Environment: ' . $this->api()->getEnvironmentLabel($environment));
+                $this->stdErr->writeln('Environment: ' . $this->api()->getEnvironmentLabel($environment, 'info', true));
             }
             if ($appName) {
                 $this->stdErr->writeln('Application name: <info>' . $appName . '</info>');

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1026,18 +1026,17 @@ class Api
      *
      * @return string
      */
-    public function getEnvironmentLabel(Environment $environment, $tag = 'info', $showType = true)
+    public function getEnvironmentLabel(Environment $environment, $tag = 'info', $showType = false)
     {
         $id = $environment->id;
         $title = $environment->title;
         $type = $environment->type;
-        $use_title = strlen($title) > 0 && $title !== $id && strtolower($title) !== $id;
-        $use_type = $showType && $type !== null && $type !== $id;
-        $pattern = $use_title ? '%2$s (%3$s)' : '%3$s';
+        $showTitle = strlen($title) > 0 && strtolower($title) !== $id;
+        $pattern = $showTitle ? '%2$s (%3$s)' : '%3$s';
         if ($tag !== false) {
-            $pattern = $use_title ? '<%1$s>%2$s</%1$s> (%3$s)' : '<%1$s>%3$s</%1$s>';
+            $pattern = $showTitle ? '<%1$s>%2$s</%1$s> (%3$s)' : '<%1$s>%3$s</%1$s>';
         }
-        if ($use_type) {
+        if ($showType) {
             $pattern .= $tag !== false ? ' (type: <%1$s>%4$s</%1$s>)' : ' (type: %4$s)';
         }
 


### PR DESCRIPTION
Omit the "type" when labelling an environment, except in a few places