### PR TITLE
Add api.write_user_ssh_config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -184,6 +184,15 @@ api:
   # Overridden by {application.env_prefix}AUTO_LOAD_SSH_CERT env var
   auto_load_ssh_cert: true
 
+  # Whether the user's SSH config file (~/.ssh/config) can be written automatically.
+  #
+  # The file is validated when SSH certificates are installed or refreshed.
+  #
+  # Setting this to true means it will be created or updated automatically,
+  # null means the user will be asked, false means it will not be touched
+  # though a recommendation will be displayed.
+  write_user_ssh_config: null
+
   # Whether the Auth API is enabled.
   auth: true
 

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -213,6 +213,13 @@ class SshConfig {
         $manualMessage = 'To configure SSH, add the following lines to: <comment>' . $filename . '</comment>'
             . "\n" . $suggestedConfig;
 
+        $writeUserSshConfig = $this->config->getWithDefault('api.write_user_ssh_config', null);
+        $writeUserSshConfig = $writeUserSshConfig === null ? null : (bool) $writeUserSshConfig;
+        if ($writeUserSshConfig === false) {
+            $this->stdErr->writeln($manualMessage);
+            return true;
+        }
+
         if (file_exists($filename)) {
             $currentContents = file_get_contents($filename);
             if ($currentContents === false) {
@@ -224,13 +231,13 @@ class SshConfig {
                 return true;
             }
             $this->stdErr->writeln('Checking SSH configuration file: <info>' . $filename . '</info>');
-            if (!$questionHelper->confirm('Do you want to update the file automatically?')) {
+            if ($writeUserSshConfig !== true && !$questionHelper->confirm('Do you want to update the file automatically?')) {
                 $this->stdErr->writeln($manualMessage);
                 return false;
             }
             $creating = false;
         } elseif ($this->fs->canWrite($filename)) {
-            if (!$questionHelper->confirm('Do you want to create an SSH configuration file automatically?')) {
+            if ($writeUserSshConfig !== true && !$questionHelper->confirm('Do you want to create an SSH configuration file automatically?')) {
                 $this->stdErr->writeln($manualMessage);
                 return false;
             }


### PR DESCRIPTION
Corresponds with `PLATFORMSH_CLI_API_WRITE_USER_SSH_CONFIG` variable.

`null` (default) = ask to create/update config
`true` or truthy = create/update config automatically without asking
`false` or falsy = don't create/update config, display suggested config
