### PR TITLE
Add new metrics commands: `metrics`, `cpu`, and `mem`

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -195,7 +195,11 @@ class Application extends ParentApplication
         $commands[] = new Command\Organization\User\OrganizationUserListCommand();
         $commands[] = new Command\Organization\User\OrganizationUserProjectsCommand();
         $commands[] = new Command\Organization\User\OrganizationUserUpdateCommand();
+        $commands[] = new Command\Metrics\AllMetricsCommand();
+        $commands[] = new Command\Metrics\CpuCommand();
+        $commands[] = new Command\Metrics\CurlCommand();
         $commands[] = new Command\Metrics\DiskUsageCommand();
+        $commands[] = new Command\Metrics\MemCommand();
         $commands[] = new Command\Project\ProjectClearBuildCacheCommand();
         $commands[] = new Command\Project\ProjectCurlCommand();
         $commands[] = new Command\Project\ProjectCreateCommand();

--- a/src/Command/Metrics/AllMetricsCommand.php
+++ b/src/Command/Metrics/AllMetricsCommand.php
@@ -1,0 +1,137 @@
+<?php
+namespace Platformsh\Cli\Command\Metrics;
+
+use Khill\Duration\Duration;
+use Platformsh\Cli\Model\Metrics\Field;
+use Platformsh\Cli\Service\PropertyFormatter;
+use Platformsh\Cli\Service\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AllMetricsCommand extends MetricsCommandBase
+{
+    protected $stability = self::STABILITY_BETA;
+    protected $preferredName = 'metrics';
+
+    private $tableHeader = [
+        'timestamp' => 'Timestamp',
+        'service' => 'Service',
+        'type' => 'Type',
+
+        'cpu_used' => 'CPU used',
+        'cpu_limit' => 'CPU limit',
+        'cpu_percent' => 'CPU %',
+
+        'mem_used' => 'Memory used',
+        'mem_limit' => 'Memory limit',
+        'mem_percent' => 'Memory %',
+
+        'disk_used' => 'Disk used',
+        'disk_limit' => 'Disk limit',
+        'disk_percent' => 'Disk %',
+
+        'inodes_used' => 'Inodes used',
+        'inodes_limit' => 'Inodes limit',
+        'inodes_percent' => 'Inodes %',
+
+        'tmp_disk_used' => '/tmp used',
+        'tmp_disk_limit' => '/tmp limit',
+        'tmp_disk_percent' => '/tmp %',
+
+        'tmp_inodes_used' => '/tmp inodes used',
+        'tmp_inodes_limit' => '/tmp inodes limit',
+        'tmp_inodes_percent' => '/tmp inodes %',
+    ];
+
+    private $defaultColumns = ['timestamp', 'service', 'cpu_percent', 'mem_percent', 'disk_percent', 'tmp_disk_percent'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('metrics:all')
+            ->setAliases(['met', 'metrics'])
+            ->setDescription('Show CPU, disk and memory metrics for an environment');
+        $this->addExample('Show metrics for the last ' . (new Duration())->humanize(self::DEFAULT_RANGE));
+        $this->addExample('Show metrics in five-minute intervals over the last hour', '-i 5m -r 1h');
+        $this->addExample('Show metrics for all SQL services', '--type mariadb,%sql');
+        $this->addMetricsOptions()
+            ->addProjectOption()
+            ->addEnvironmentOption();
+        Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
+        PropertyFormatter::configureInput($this->getDefinition());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $timeSpec = $this->validateTimeInput($input);
+        if ($timeSpec === false) {
+            return 1;
+        }
+
+        $this->validateInput($input, false, true);
+
+        /** @var \Platformsh\Cli\Service\Table $table */
+        $table = $this->getService('table');
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->displayEnvironmentHeader();
+            $this->stdErr->writeln(\sprintf(
+                'Metrics at <info>%s</info> intervals from <info>%s</info> to <info>%s</info>:',
+                (new Duration())->humanize($timeSpec->getInterval()),
+                \date('Y-m-d H:i:s', $timeSpec->getStartTime()),
+                \date('Y-m-d H:i:s', $timeSpec->getEndTime())
+            ));
+        }
+
+        // Only request the metrics fields that will be displayed.
+        //
+        // The fields are the selected column names (according to the $table
+        // service), filtered to only those that contain an underscore.
+        $fieldNames = array_filter($table->columnsToDisplay($this->tableHeader, $this->defaultColumns), function ($c) { return strpos($c, '_') !== false; });
+        $values = $this->fetchMetrics($input, $timeSpec, $this->getSelectedEnvironment(), $fieldNames);
+        if ($values === false) {
+            return 1;
+        }
+
+        $rows = $this->buildRows($values, [
+            'cpu_used' => new Field('cpu_used', Field::FORMAT_ROUNDED_2DP),
+            'cpu_limit' => new Field('cpu_limit', Field::FORMAT_ROUNDED_2DP),
+            'cpu_percent' => new Field('cpu_percent', Field::FORMAT_PERCENT),
+
+            'mem_used' => new Field('mem_used', Field::FORMAT_MEMORY),
+            'mem_limit' => new Field('mem_limit', Field::FORMAT_MEMORY),
+            'mem_percent' => new Field('mem_percent', Field::FORMAT_PERCENT),
+
+            'disk_used' => new Field('disk_used', Field::FORMAT_DISK),
+            'disk_limit' => new Field('disk_limit', Field::FORMAT_DISK),
+            'disk_percent' => new Field('disk_percent', Field::FORMAT_PERCENT),
+
+            'tmp_disk_used' => new Field('tmp_disk_used', Field::FORMAT_DISK),
+            'tmp_disk_limit' => new Field('tmp_disk_limit', Field::FORMAT_DISK),
+            'tmp_disk_percent' => new Field('tmp_disk_percent', Field::FORMAT_PERCENT),
+
+            'inodes_used' => new Field('inodes_used', Field::FORMAT_ROUNDED),
+            'inodes_limit' => new Field('inodes_used', Field::FORMAT_ROUNDED),
+            'inodes_percent' => new Field('inodes_percent', Field::FORMAT_PERCENT),
+
+            'tmp_inodes_used' => new Field('tmp_inodes_used', Field::FORMAT_ROUNDED),
+            'tmp_inodes_limit' => new Field('tmp_inodes_used', Field::FORMAT_ROUNDED),
+            'tmp_inodes_percent' => new Field('tmp_inodes_percent', Field::FORMAT_PERCENT),
+        ]);
+
+        $table->render($rows, $this->tableHeader, $this->defaultColumns);
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->explainHighMemoryServices();
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln('You can run the <info>cpu</info>, <info>disk</info> and <info>mem</info> commands for more detail.');
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Metrics/CpuCommand.php
+++ b/src/Command/Metrics/CpuCommand.php
@@ -1,0 +1,81 @@
+<?php
+namespace Platformsh\Cli\Command\Metrics;
+
+use Khill\Duration\Duration;
+use Platformsh\Cli\Model\Metrics\Field;
+use Platformsh\Cli\Service\PropertyFormatter;
+use Platformsh\Cli\Service\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CpuCommand extends MetricsCommandBase
+{
+    protected $stability = self::STABILITY_BETA;
+
+    private $tableHeader = [
+        'timestamp' => 'Timestamp',
+        'service' => 'Service',
+        'type' => 'Type',
+        'used' => 'Used',
+        'limit' => 'Limit',
+        'percent' => 'Used %',
+    ];
+
+    private $defaultColumns = ['timestamp', 'service', 'used', 'limit', 'percent'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('metrics:cpu')
+            ->setAliases(['cpu'])
+            ->setDescription('Show CPU usage of an environment');
+        $this->addMetricsOptions()
+            ->addProjectOption()
+            ->addEnvironmentOption();
+        Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
+        PropertyFormatter::configureInput($this->getDefinition());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $timeSpec = $this->validateTimeInput($input);
+        if ($timeSpec === false) {
+            return 1;
+        }
+
+        $this->validateInput($input, false, true);
+
+        /** @var \Platformsh\Cli\Service\Table $table */
+        $table = $this->getService('table');
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->displayEnvironmentHeader();
+            $this->stdErr->writeln(\sprintf(
+                'Average CPU usage at <info>%s</info> intervals from <info>%s</info> to <info>%s</info>:',
+                (new Duration())->humanize($timeSpec->getInterval()),
+                \date('Y-m-d H:i:s', $timeSpec->getStartTime()),
+                \date('Y-m-d H:i:s', $timeSpec->getEndTime())
+            ));
+        }
+
+        $values = $this->fetchMetrics($input, $timeSpec, $this->getSelectedEnvironment(), ['cpu_used', 'cpu_percent', 'cpu_limit']);
+        if ($values === false) {
+            return 1;
+        }
+
+        $rows = $this->buildRows($values, [
+            'used' => new Field('cpu_used', Field::FORMAT_ROUNDED_2DP),
+            'limit' => new Field('cpu_limit', Field::FORMAT_ROUNDED_2DP),
+            'percent' => new Field('cpu_percent', Field::FORMAT_PERCENT),
+        ]);
+
+        $table->render($rows, $this->tableHeader, $this->defaultColumns);
+
+        return 0;
+    }
+}

--- a/src/Command/Metrics/CurlCommand.php
+++ b/src/Command/Metrics/CurlCommand.php
@@ -1,0 +1,41 @@
+<?php
+namespace Platformsh\Cli\Command\Metrics;
+
+use Platformsh\Cli\Service\CurlCli;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CurlCommand extends MetricsCommandBase
+{
+    protected $hiddenInList = true;
+
+    protected function configure()
+    {
+        $this->setName('metrics:curl')
+            ->setDescription("Run an authenticated cURL request on an environment's metrics API");
+
+        CurlCli::configureInput($this->getDefinition());
+
+        $this->addProjectOption();
+        $this->addEnvironmentOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input, false, true);
+
+        // Initialize the API service so that it gets CommandBase's event listeners
+        // (allowing for auto login).
+        $this->api();
+
+        $link = $this->getMetricsLink($this->getSelectedEnvironment());
+        if (!$link) {
+            return 1;
+        }
+
+        /** @var CurlCli $curl */
+        $curl = $this->getService('curl_cli');
+
+        return $curl->run($link['href'], $input, $output);
+    }
+}

--- a/src/Command/Metrics/DiskUsageCommand.php
+++ b/src/Command/Metrics/DiskUsageCommand.php
@@ -1,82 +1,46 @@
 <?php
 namespace Platformsh\Cli\Command\Metrics;
 
-use GuzzleHttp\Exception\BadResponseException;
 use Khill\Duration\Duration;
-use Platformsh\Cli\Command\CommandBase;
-use Platformsh\Cli\Console\ProgressMessage;
+use Platformsh\Cli\Model\Metrics\Field;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
-use Platformsh\Cli\Util\JsonLines;
-use Platformsh\Client\Exception\ApiResponseException;
-use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DiskUsageCommand extends CommandBase
+class DiskUsageCommand extends MetricsCommandBase
 {
-    const RED_WARNING_THRESHOLD = 90; // percent
-    const YELLOW_WARNING_THRESHOLD = 80; // percent
-
-    const MIN_INTERVAL = 60; // 1 minute
-    const MAX_INTERVAL = 3600; // 1 hour
-
-    const MIN_RANGE = 300; // 5 minutes
-    const DEFAULT_RANGE = 600;
-
     private $tableHeader = [
         'timestamp' => 'Timestamp',
+        'service' => 'Service',
+        'type' => 'Type',
         'used' => 'Used',
         'limit' => 'Limit',
         'percent' => 'Used %',
         'iused' => 'Inodes used',
         'ilimit' => 'Inodes limit',
         'ipercent' => 'Inodes %',
-        'interval' => 'Interval',
+        'tmp_used' => '/tmp used',
+        'tmp_limit' => '/tmp limit',
+        'tmp_percent' => '/tmp %',
+        'tmp_iused' => '/tmp inodes used',
+        'tmp_ilimit' => '/tmp inodes limit',
+        'tmp_ipercent' => '/tmp inodes %',
     ];
-    private $defaultColumns = ['timestamp', 'used', 'limit', 'percent', 'ipercent'];
-
-    public function isEnabled()
-    {
-        if (!$this->config()->getWithDefault('api.metrics', false)) {
-            return false;
-        }
-        return parent::isEnabled();
-    }
+    private $defaultColumns = ['timestamp', 'service', 'used', 'limit', 'percent', 'ipercent', 'tmp_percent'];
 
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
-        $duration = new Duration();
-
         $this->setName('metrics:disk-usage')
             ->setAliases(['disk'])
-            ->setDescription('Show disk usage on a service')
-            ->addOption('service', 's', InputOption::VALUE_REQUIRED, 'The service name')
-            ->addOption('type', null, InputOption::VALUE_REQUIRED, 'The service type (if the service name is not provided), e.g. mysql, pgsql, mongodb, etc. The type version is not required.')
-            ->addOption('range', 'r', InputOption::VALUE_REQUIRED,
-                'The time range. Metrics will be loaded for this duration until the end time (--to).'
-                . "\n" . 'You can specify units: hours (h), minutes (m), or seconds (s).'
-                . "\n" . \sprintf(
-                    'Minimum <comment>%s</comment>, maximum <comment>8h</comment> or more (depending on the project), default <comment>%s</comment>.',
-                    $duration->humanize(self::MIN_RANGE),
-                    $duration->humanize(self::DEFAULT_RANGE)
-                )
-            )
-            // The $default is left at null so the lack of input can be detected.
-            ->addOption('interval', 'i', InputOption::VALUE_REQUIRED,
-                'The time interval. Defaults to a division of the range.'
-                . "\n" . 'You can specify units: hours (h), minutes (m), or seconds (s).'
-                . "\n" . \sprintf('Minimum <comment>%s</comment>, maximum <comment>%s</comment>.', $duration->humanize(self::MIN_INTERVAL), $duration->humanize(self::MAX_INTERVAL))
-            )
-            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'The end time. Defaults to now.')
-            ->addOption('bytes', 'B', InputOption::VALUE_NONE, 'Show sizes in bytes')
-            ->addOption('latest', '1', InputOption::VALUE_NONE, 'Show only the latest single data point');
-        $this->addExample('Show the persistent disk usage of a mysql service in five-minute intervals over the last hour', '--type mysql -i 5m -r 1h');
-        $this->addProjectOption()
+            ->setDescription('Show disk usage of an environment')
+            ->addOption('bytes', 'B', InputOption::VALUE_NONE, 'Show sizes in bytes');
+        $this->addMetricsOptions()
+            ->addProjectOption()
             ->addEnvironmentOption();
         Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
         PropertyFormatter::configureInput($this->getDefinition());
@@ -87,287 +51,54 @@ class DiskUsageCommand extends CommandBase
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $intervalSeconds = null;
-        if ($intervalStr = $input->getOption('interval')) {
-            $duration = new Duration();
-            $intervalSeconds = $duration->toSeconds($intervalStr);
-            if (empty($intervalSeconds)) {
-                $this->stdErr->writeln('Invalid --interval: <error>' . $intervalStr . '</error>');
-                return 1;
-            } elseif ($intervalSeconds < self::MIN_INTERVAL) {
-                $this->stdErr->writeln(\sprintf('The --interval <error>%s</error> is too short: it must be at least %d seconds.', $intervalStr, self::MIN_INTERVAL));
-                return 1;
-            } elseif ($intervalSeconds > self::MAX_INTERVAL) {
-                $this->stdErr->writeln(\sprintf('The --interval <error>%s</error> is too long: it must be %d seconds or less.', $intervalStr, self::MAX_INTERVAL));
-                return 1;
-            }
-            $intervalSeconds = \intval($intervalSeconds);
-        }
-
-        if ($to = $input->getOption('to')) {
-            $endTime = \strtotime($to);
-            if (!$endTime) {
-                $this->stdErr->writeln('Failed to parse --to time: ' . $to);
-                return 1;
-            }
-        } else {
-            $endTime = time();
-        }
-        if ($rangeStr = $input->getOption('range')) {
-            $rangeSeconds = (new Duration())->toSeconds($rangeStr);
-            if (empty($rangeSeconds)) {
-                $this->stdErr->writeln('Invalid --range: <error>' . $rangeStr . '</error>');
-                return 1;
-            } elseif ($rangeSeconds < self::MIN_RANGE) {
-                $this->stdErr->writeln(\sprintf('The --range <error>%s</error> is too short: it must be at least %d seconds (%s).', $rangeStr, self::MIN_RANGE, (new Duration())->humanize(self::MIN_RANGE)));
-                return 1;
-            }
-            $rangeSeconds = \intval($rangeSeconds);
-        } else {
-            $rangeSeconds = self::DEFAULT_RANGE;
-        }
-
-        if ($intervalSeconds === null) {
-            $intervalSeconds = $rangeSeconds > self::MIN_INTERVAL * 10 ? $this->roundDuration($rangeSeconds / 10) : self::MIN_INTERVAL;
-        }
-
-        if ($input->getOption('latest')) {
-            $rangeSeconds = $intervalSeconds;
-        }
-
-        $startTime = $endTime - $rangeSeconds;
-
-        $this->validateInput($input);
-
-        $environment = $this->getSelectedEnvironment();
-
-        $environmentData = $environment->getData();
-        if (!isset($environmentData['_links']['#metrics'])) {
-            $this->stdErr->writeln(\sprintf('The metrics API is not currently available on the environment: %s', $this->api()->getEnvironmentLabel($environment, 'error')));
-
+        $timeSpec = $this->validateTimeInput($input);
+        if ($timeSpec === false) {
             return 1;
         }
-        if (!isset($environmentData['_links']['#metrics'][0]['href'], $environmentData['_links']['#metrics'][0]['collection'])) {
-            $this->stdErr->writeln(\sprintf('Unable to find metrics URLs for the environment: %s', $this->api()->getEnvironmentLabel($environment, 'error')));
-
-            return 1;
-        }
-
-        $metricsApiUrl = $environmentData['_links']['#metrics'][0]['href'] . '/v1/metrics/query';
-        $metricsApiCollection = $environmentData['_links']['#metrics'][0]['collection'];
-
-        $query = [
-            'stream' => [
-                'stream' => 'metrics',
-                'collection' => $metricsApiCollection,
-            ],
-            'interval' => $intervalSeconds . 's',
-            'fields' => [
-                [
-                    'name' => 'used',
-                    'expr' => 'AVG(`disk.space.used`)',
-                ],
-                [
-                    'name' => 'limit',
-                    'expr' => 'AVG(`disk.space.limit`)',
-                ],
-                [
-                    'name' => 'percent',
-                    'expr' => 'AVG(`disk.space.used`/`disk.space.limit`)*100',
-                ],
-                [
-                    'name' => 'iused',
-                    'expr' => 'AVG(`disk.inodes.used`)',
-                ],
-                [
-                    'name' => 'ilimit',
-                    'expr' => 'AVG(`disk.inodes.limit`)',
-                ],
-                [
-                    'name' => 'ipercent',
-                    'expr' => 'AVG(`disk.inodes.used`/`disk.inodes.limit`)*100',
-                ],
-            ],
-            'range' => [
-                'from' => date('Y-m-d\TH:i:s.uP', $startTime),
-                'to' => date('Y-m-d\TH:i:s.uP', $endTime),
-            ],
-        ];
-
-        $deployment = $this->getSelectedEnvironment()->getCurrentDeployment();
-
-        $services = \array_merge($deployment->webapps, $deployment->services);
-        if (empty($services)) {
-            $this->stdErr->writeln('No services found.');
-            return 1;
-        }
-
-        $serviceName = $input->getOption('service');
-        if (!$serviceName) {
-            $type = $input->getOption('type');
-
-            $choices = [];
-            /** @var \Platformsh\Client\Model\Deployment\WebApp|\Platformsh\Client\Model\Deployment\Service $service */
-            foreach ($services as $name => $service) {
-                if ($type !== null && $service->type !== $type && \strpos($service->type, $type . ':') !== 0) {
-                    continue;
-                }
-                if ($service->disk > 0) {
-                    $choices[$name] = \sprintf('%s (type: %s)', $name, $service->type);
-                }
-            }
-            if (empty($choices)) {
-                if ($type !== null) {
-                    $this->stdErr->writeln(\sprintf('No services found with type <error>%s</error> and persistent disk space configured.', $type));
-                } else {
-                    $this->stdErr->writeln('No services found with persistent disk space configured.');
-                }
-                $this->stdErr->writeln('');
-                $this->stdErr->writeln(\sprintf('To list services, run: <info>%s services</info>', $this->config()->get('application.executable')));
-                return 1;
-            }
-
-            /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
-            $questionHelper = $this->getService('question_helper');
-            $serviceName = $questionHelper->choose($choices, 'Enter a number to choose a service (<fg=cyan>-s</>):');
-            if ($serviceName === null) {
-                $this->stdErr->writeln('A <error>--service</error> is required (the name of an app or service).');
-                return 1;
-            }
-        }
-        if (!isset($services[$serviceName])) {
-            $this->stdErr->writeln(\sprintf('Service not found: <error>%s</error>', $serviceName));
-            return 1;
-        }
-        /** @var \Platformsh\Client\Model\Deployment\WebApp|\Platformsh\Client\Model\Deployment\Service $service */
-        $service = $services[$serviceName];
-
-        $query['filters'][] = ['key' => 'service', 'value' => $serviceName];
-
-        // Show persistent disk usage only, i.e. from the /mnt mountpoint.
-        // TODO can this be hardcoded?
-        $query['filters'][] = ['key' => 'mountpoint', 'value' => '/mnt'];
-
-        if ($this->stdErr->isDebug()) {
-            $this->debug("Metrics query: \n" . \json_encode($query, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        }
-
-        $progress = new ProgressMessage($output);
-        $progress->showIfOutputDecorated('Loading metrics...');
-
-        $client = $this->api()->getHttpClient();
-        $request = $client->createRequest('POST', $metricsApiUrl, ['json' => $query]);
-        try {
-            $result = $client->send($request);
-            $progress->done();
-        } catch (BadResponseException $e) {
-            $progress->done();
-            throw ApiResponseException::create($request, $e->getResponse(), $e);
-        }
-
-        $content = $result->getBody()->__toString();
-        $items = JsonLines::decode($content);
-        if (empty($items)) {
-            $this->stdErr->writeln('No data points found.');
-            return 1;
-        }
-
-        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
-        $formatter = $this->getService('property_formatter');
 
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
+        $table->removeDeprecatedColumns(['interval'], '', $input, $output);
+
+        $this->validateInput($input, false, true);
 
         if (!$table->formatIsMachineReadable()) {
-            $this->stdErr->writeln('Project: ' . $this->api()->getProjectLabel($this->getSelectedProject()));
-            $this->stdErr->writeln('Environment: ' . $this->api()->getEnvironmentLabel($this->getSelectedEnvironment()));
-            $this->stdErr->writeln(\sprintf('Service or app: <info>%s</info> (type: <info>%s</info>)', $serviceName, $service->type));
-            $this->stdErr->writeln('');
+            $this->displayEnvironmentHeader();
             $this->stdErr->writeln(\sprintf(
                 'Average disk usage at <info>%s</info> intervals from <info>%s</info> to <info>%s</info>:',
-                (new Duration())->humanize($intervalSeconds),
-                \date('Y-m-d H:i:s', $startTime),
-                \date('Y-m-d H:i:s', $endTime)
+                (new Duration())->humanize($timeSpec->getInterval()),
+                \date('Y-m-d H:i:s', $timeSpec->getStartTime()),
+                \date('Y-m-d H:i:s', $timeSpec->getEndTime())
             ));
         }
 
-        $rows = [];
+        $values = $this->fetchMetrics($input, $timeSpec, $this->getSelectedEnvironment(), ['disk_used', 'disk_percent', 'disk_limit', 'inodes_used', 'inodes_percent', 'inodes_limit']);
+        if ($values === false) {
+            return 1;
+        }
 
         $bytes = $input->getOption('bytes');
 
-        $valuesByTimestamp = [];
-        foreach ($items as $item) {
-            $time = $item['point']['timestamp'];
-            foreach ($item['point']['values'] as $value) {
-                $name = $value['info']['name'];
-                $valuesByTimestamp[$time][$name] = $value;
-            }
-        }
+        $rows = $this->buildRows($values, [
+            'used' => new Field('disk_used', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_DISK),
+            'limit' => new Field('disk_limit', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_DISK),
+            'percent' => new Field('disk_percent', Field::FORMAT_PERCENT),
 
-        if ($input->getOption('latest')) {
-            \ksort($valuesByTimestamp, SORT_NATURAL);
-            $valuesByTimestamp = \array_slice($valuesByTimestamp, -1, null, true);
-        }
+            'iused' => new Field('inodes_used', FIELD::FORMAT_ROUNDED),
+            'ilimit' => new Field('inodes_limit', FIELD::FORMAT_ROUNDED),
+            'ipercent' => new Field('inodes_percent', Field::FORMAT_PERCENT),
 
-        foreach ($valuesByTimestamp as $time => $values) {
-            $row = [
-                'timestamp' => $formatter->formatDate($time),
-                'used' => '',
-                'limit' => '',
-                'percent' => '',
-                'iused' => '',
-                'ilimit' => '',
-                'ipercent' => '',
-                'interval' => $intervalSeconds,
-            ];
-            foreach (['', 'i'] as $prefix) {
-                if (isset($values[$prefix . 'used']['value']['max'])) {
-                    $value = $values[$prefix . 'used']['value']['max'];
-                    $row[$prefix . 'used'] = $bytes || $prefix === 'i' ? $value : FormatterHelper::formatMemory($value);
-                }
-                if (isset($values[$prefix . 'limit']['value'])) {
-                    if (isset($values[$prefix . 'limit']['value']['min'])) {
-                        $value = $values[$prefix . 'limit']['value']['min'];
-                        $row[$prefix . 'limit'] = $bytes || $prefix === 'i' ? $value : FormatterHelper::formatMemory($value);
-                    }
-                    // TODO sometimes the 'min' value is omitted, there is only a max
-                    elseif (isset($values[$prefix . 'limit']['value']['max'])) {
-                        $value = $values[$prefix . 'limit']['value']['max'];
-                        $row[$prefix . 'limit'] = $bytes || $prefix === 'i' ? $value : FormatterHelper::formatMemory($value);
-                    }
-                }
-                if (isset($values[$prefix . 'percent']['value']['sum'])) {
-                    $value = $values[$prefix . 'percent']['value']['sum'];
-                    if ($value >= self::RED_WARNING_THRESHOLD) {
-                        $row[$prefix . 'percent'] = \sprintf('<options=bold;fg=red>%.1f%%</>', $value);
-                    } elseif ($value >= self::YELLOW_WARNING_THRESHOLD) {
-                        $row[$prefix . 'percent'] = \sprintf('<options=bold;fg=yellow>%.1f%%</>', $value);
-                    } else {
-                        $row[$prefix . 'percent'] = \sprintf('%.1f%%', $value);
-                    }
-                }
-            }
-            $rows[] = $row;
-        }
+            'tmp_used' => new Field('tmp_disk_used', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_DISK),
+            'tmp_limit' => new Field('tmp_disk_limit', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_DISK),
+            'tmp_percent' => new Field('tmp_disk_percent', Field::FORMAT_PERCENT),
+
+            'tmp_iused' => new Field('tmp_inodes_used', Field::FORMAT_ROUNDED),
+            'tmp_ilimit' => new Field('tmp_inodes_used', Field::FORMAT_ROUNDED),
+            'tmp_ipercent' => new Field('tmp_inodes_percent', Field::FORMAT_PERCENT),
+        ]);
 
         $table->render($rows, $this->tableHeader, $this->defaultColumns);
 
         return 0;
-    }
-
-    /**
-     * @param int|float $seconds
-     *
-     * @return int
-     */
-    private function roundDuration($seconds)
-    {
-        $targets = [3600 * 24, 3600 * 6, 3600 * 3, 3600, 1800, 900, 600, 300, 60, 10];
-        foreach ($targets as $target) {
-            if ($seconds > $target) {
-                return (int) \ceil($seconds - $seconds % $target);
-            }
-        }
-        return (int) \ceil($seconds);
     }
 }

--- a/src/Command/Metrics/MemCommand.php
+++ b/src/Command/Metrics/MemCommand.php
@@ -1,0 +1,89 @@
+<?php
+namespace Platformsh\Cli\Command\Metrics;
+
+use Khill\Duration\Duration;
+use Platformsh\Cli\Model\Metrics\Field;
+use Platformsh\Cli\Service\PropertyFormatter;
+use Platformsh\Cli\Service\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MemCommand extends MetricsCommandBase
+{
+    protected $stability = self::STABILITY_BETA;
+
+    private $tableHeader = [
+        'timestamp' => 'Timestamp',
+        'service' => 'Service',
+        'type' => 'Type',
+        'used' => 'Used',
+        'limit' => 'Limit',
+        'percent' => 'Used %',
+    ];
+
+    private $defaultColumns = ['timestamp', 'service', 'used', 'limit', 'percent'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('metrics:memory')
+            ->setAliases(['mem', 'memory'])
+            ->setDescription('Show memory usage of an environment')
+            ->addOption('bytes', 'B', InputOption::VALUE_NONE, 'Show sizes in bytes');
+        $this->addMetricsOptions()
+            ->addProjectOption()
+            ->addEnvironmentOption();
+        Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
+        PropertyFormatter::configureInput($this->getDefinition());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $timeSpec = $this->validateTimeInput($input);
+        if ($timeSpec === false) {
+            return 1;
+        }
+
+        $this->validateInput($input, false, true);
+
+        /** @var \Platformsh\Cli\Service\Table $table */
+        $table = $this->getService('table');
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->displayEnvironmentHeader();
+            $this->stdErr->writeln(\sprintf(
+                'Average memory usage at <info>%s</info> intervals from <info>%s</info> to <info>%s</info>:',
+                (new Duration())->humanize($timeSpec->getInterval()),
+                \date('Y-m-d H:i:s', $timeSpec->getStartTime()),
+                \date('Y-m-d H:i:s', $timeSpec->getEndTime())
+            ));
+        }
+
+        $values = $this->fetchMetrics($input, $timeSpec, $this->getSelectedEnvironment(), ['mem_used', 'mem_percent', 'mem_limit']);
+        if ($values === false) {
+            return 1;
+        }
+
+        $bytes = $input->getOption('bytes');
+
+        $rows = $this->buildRows($values, [
+            'used' => new Field('mem_used', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_MEMORY),
+            'limit' => new Field('mem_limit', $bytes ? Field::FORMAT_ROUNDED : Field::FORMAT_MEMORY),
+            'percent' => new Field('mem_percent', Field::FORMAT_PERCENT),
+        ]);
+
+        $table->render($rows, $this->tableHeader, $this->defaultColumns);
+
+        if (!$table->formatIsMachineReadable()) {
+            $this->explainHighMemoryServices();
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Metrics/MetricsCommandBase.php
+++ b/src/Command/Metrics/MetricsCommandBase.php
@@ -1,0 +1,553 @@
+<?php
+
+namespace Platformsh\Cli\Command\Metrics;
+
+use GuzzleHttp\Exception\BadResponseException;
+use Khill\Duration\Duration;
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\AdaptiveTableCell;
+use Platformsh\Cli\Console\ArrayArgument;
+use Platformsh\Cli\Model\Metrics\Field;
+use Platformsh\Cli\Model\Metrics\Query;
+use Platformsh\Cli\Model\Metrics\Sketch;
+use Platformsh\Cli\Model\Metrics\TimeSpec;
+use Platformsh\Cli\Util\JsonLines;
+use Platformsh\Cli\Util\Wildcard;
+use Platformsh\Client\Exception\ApiResponseException;
+use Platformsh\Client\Model\Environment;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class MetricsCommandBase extends CommandBase
+{
+    const MIN_INTERVAL = 60; // 1 minute
+    const MAX_INTERVAL = 3600; // 1 hour
+
+    const MIN_RANGE = 300; // 5 minutes
+    const DEFAULT_RANGE = 600;
+
+    /**
+     * @var bool Whether services have been identified that use high memory.
+     */
+    private $foundHighMemoryServices = false;
+
+    private $fields = [
+        // Grid.
+        'local' => [
+            'cpu_used' => "SUM((`cpu.user` + `cpu.kernel`) / `interval`, 'service')",
+            'cpu_percent' => "SUM(100 * (`cpu.user` + `cpu.kernel`) / (`interval` * `cpu.cores`), 'service')",
+            'cpu_limit' => "AVG(`cpu.cores`, 'service')",
+
+            'mem_used' => "SUM(`memory.apps` + `memory.kernel` + `memory.buffers`, 'service')",
+            'mem_percent' => "SUM(100 * (`memory.apps` + `memory.kernel` + `memory.buffers`) / `memory.limit`, 'service')",
+            'mem_limit' => "AVG(`memory.limit`, 'service')",
+
+            'disk_used' => "AVG(`disk.space.used`, 'mountpoint', 'service')",
+            'inodes_used' => "AVG(`disk.inodes.used`, 'mountpoint', 'service')",
+            'disk_percent' => "AVG((`disk.space.used`/`disk.space.limit`)*100, 'mountpoint', 'service')",
+            'inodes_percent' => "AVG((`disk.inodes.used`/`disk.inodes.limit`)*100, 'mountpoint', 'service')",
+            'disk_limit' => "AVG(`disk.space.limit`, 'mountpoint', 'service')",
+            'inodes_limit' => "AVG(`disk.inodes.limit`, 'mountpoint', 'service')",
+        ],
+        // Dedicated Generation 3 (DG3).
+        'dedicated' => [
+            'cpu_used' => "AVG(SUM((`cpu.user` + `cpu.kernel`) / `interval`, 'hostname', 'service', 'instance'), 'service')",
+            'cpu_percent' => "AVG(100 * SUM((`cpu.user` + `cpu.kernel`) / (`interval` * `cpu.cores`), 'hostname', 'service', 'instance'), 'service')",
+            'cpu_limit' => "AVG(`cpu.cores`, 'service')",
+
+            'disk_used' => "AVG(`disk.space.used`, 'mountpoint', 'service')",
+            'inodes_used' => "AVG(`disk.inodes.used`, 'mountpoint', 'service')",
+            'disk_percent' => "AVG((`disk.space.used`/`disk.space.limit`)*100, 'mountpoint', 'service')",
+            'inodes_percent' => "AVG((`disk.inodes.used`/`disk.inodes.limit`)*100, 'mountpoint', 'service')",
+            'disk_limit' => "AVG(`disk.space.limit`, 'mountpoint', 'service')",
+            'inodes_limit' => "AVG(`disk.inodes.limit`, 'mountpoint', 'service')",
+
+            'mem_used' => "AVG(SUM(`memory.apps` + `memory.kernel` + `memory.buffers`, 'hostname', 'service', 'instance'), 'service')",
+            'mem_percent' => "AVG(SUM(100 * (`memory.apps` + `memory.kernel` + `memory.buffers`) / `memory.limit`, 'hostname', 'service', 'instance'), 'service')",
+            'mem_limit' => "AVG(`memory.limit`, 'service')",
+        ],
+        // Dedicated Generation 2 (DG2), formerly known as "Enterprise".
+        'enterprise' => [
+            'cpu_used' => "AVG(SUM((`cpu.user` + `cpu.kernel`) / `interval`, 'hostname'))",
+            'cpu_percent' => "AVG(100 * SUM((`cpu.user` + `cpu.kernel`) / (`interval` * `cpu.cores`), 'hostname'))",
+            'cpu_limit' => "AVG(`cpu.cores`, 'service')",
+
+            'mem_used' => "AVG(SUM(`memory.apps` + `memory.kernel` + `memory.buffers`, 'hostname'))",
+            'mem_percent' => "AVG(SUM(100 * (`memory.apps` + `memory.kernel` + `memory.buffers`) / `memory.limit`, 'hostname'))",
+            'mem_limit' => "AVG(`memory.limit`, 'service')",
+
+            'disk_used' => "AVG(`disk.space.used`, 'mountpoint')",
+            'inodes_used' => "AVG(`disk.inodes.used`, 'mountpoint')",
+            'disk_percent' => "AVG((`disk.space.used`/`disk.space.limit`)*100, 'mountpoint')",
+            'inodes_percent' => "AVG((`disk.inodes.used`/`disk.inodes.limit`)*100, 'mountpoint')",
+            'disk_limit' => "AVG(`disk.space.limit`, 'mountpoint')",
+            'inodes_limit' => "AVG(`disk.inodes.limit`, 'mountpoint')",
+        ],
+    ];
+
+    public function isEnabled()
+    {
+        if (!$this->config()->getWithDefault('api.metrics', false)) {
+            return false;
+        }
+        return parent::isEnabled();
+    }
+
+    protected function addMetricsOptions()
+    {
+        $duration = new Duration();
+        $this->addOption('range', 'r', InputOption::VALUE_REQUIRED,
+            'The time range. Metrics will be loaded for this duration until the end time (--to).'
+            . "\n" . 'You can specify units: hours (h), minutes (m), or seconds (s).'
+            . "\n" . \sprintf(
+                'Minimum <comment>%s</comment>, maximum <comment>8h</comment> or more (depending on the project), default <comment>%s</comment>.',
+                $duration->humanize(self::MIN_RANGE),
+                $duration->humanize(self::DEFAULT_RANGE)
+            )
+        );
+        // The $default is left at null so the lack of input can be detected.
+        $this->addOption('interval', 'i', InputOption::VALUE_REQUIRED,
+            'The time interval. Defaults to a division of the range.'
+            . "\n" . 'You can specify units: hours (h), minutes (m), or seconds (s).'
+            . "\n" . \sprintf('Minimum <comment>%s</comment>, maximum <comment>%s</comment>.', $duration->humanize(self::MIN_INTERVAL), $duration->humanize(self::MAX_INTERVAL))
+        );
+        $this->addOption('to', null, InputOption::VALUE_REQUIRED, 'The end time. Defaults to now.');
+        $this->addOption('latest', '1', InputOption::VALUE_NONE, 'Show only the latest single data point');
+        $this->addOption('service', 's', InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Filter by service or application name' . "\n" . Wildcard::HELP);
+        $this->addOption('type', null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Filter by service type (if --service is not provided). The version is not required.' . "\n" . Wildcard::HELP);
+        return $this;
+    }
+
+    /**
+     * Returns the metrics URL and collection information for the selected environment.
+     *
+     * @return array{'href': string, 'collection': string}|false
+     *   The link data or false on failure.
+     */
+    protected function getMetricsLink(Environment $environment)
+    {
+        $environmentData = $environment->getData();
+        if (!isset($environmentData['_links']['#metrics'])) {
+            $this->stdErr->writeln(\sprintf('The metrics API is not currently available on the environment: %s', $this->api()->getEnvironmentLabel($environment, 'error')));
+
+            return false;
+        }
+        if (!isset($environmentData['_links']['#metrics'][0]['href'], $environmentData['_links']['#metrics'][0]['collection'])) {
+            $this->stdErr->writeln(\sprintf('Unable to find metrics URLs for the environment: %s', $this->api()->getEnvironmentLabel($environment, 'error')));
+
+            return false;
+        }
+
+        return $environmentData['_links']['#metrics'][0];
+    }
+
+    /**
+     * Splits a dimension string into fields.
+     *
+     * @param string $dimension
+     * @return array<string, string>
+     */
+    private function dimensionFields($dimension)
+    {
+        $fields = ['service' => '', 'mountpoint' => '', 'instance' => ''];
+        foreach (explode('/', $dimension) as $field) {
+            $parts = explode('=', $field, 2);
+            if (count($parts) === 2) {
+                $fields[urldecode($parts[0])] = urldecode($parts[1]);
+            }
+        }
+        return $fields;
+    }
+
+    /**
+     * Validates input and fetches metrics.
+     *
+     * @param InputInterface $input
+     * @param TimeSpec $timeSpec
+     * @param Environment $environment
+     * @param string[] $fieldNames
+     *   An array of field names, which map to queries in $this->fields.
+     *
+     * @return false|array
+     *   False on failure, or an array of sketch values, keyed by: time, service, dimension, and name.
+     */
+    protected function fetchMetrics(InputInterface $input, TimeSpec $timeSpec, Environment $environment, $fieldNames)
+    {
+        $link = $this->getMetricsLink($environment);
+        if (!$link) {
+            return false;
+        }
+
+        $query = (new Query())
+            ->setStartTime($timeSpec->getStartTime())
+            ->setEndTime($timeSpec->getEndTime())
+            ->setInterval($timeSpec->getInterval());
+
+        $metricsQueryUrl = $link['href'] . '/v1/metrics/query';
+        $query->setCollection($link['collection']);
+
+        $deploymentType = $this->getDeploymentType($environment);
+        if (!isset($this->fields[$deploymentType])) {
+            if (($fallback = key($this->fields)) === false) {
+                throw new \InvalidArgumentException('No query fields are defined');
+            }
+            $this->stdErr->writeln(sprintf(
+                'No query fields are defined for the deployment type: <comment>%s</comment>. Falling back to: <comment>%s</comment>',
+                $deploymentType,
+                $fallback
+            ));
+            $deploymentType = $fallback;
+        }
+
+        // Add fields and expressions to the query based on the requested $fieldNames.
+        $fieldNames = array_map(function ($f) {
+            if (substr($f, 0, 4) === 'tmp_') {
+                return substr($f, 4);
+            }
+            return $f;
+        }, $fieldNames);
+        foreach ($this->fields[$deploymentType] as $name => $expression) {
+            if (in_array($name, $fieldNames)) {
+                $query->addField($name, $expression);
+            }
+        }
+
+        // Select services based on the --service or --type options.
+        $deployment = $this->api()->getCurrentDeployment($environment);
+        $allServices = array_merge($deployment->webapps, $deployment->services, $deployment->workers);
+        $servicesInput = ArrayArgument::getOption($input, 'service');
+        $selectedServiceNames = [];
+        if (!empty($servicesInput)) {
+            $selectedServiceNames = Wildcard::select(array_merge(array_keys($allServices), ['router']), $servicesInput);
+            if (!$selectedServiceNames) {
+                $this->stdErr->writeln('No services were found matching the name(s): <error>' . implode(', ', $servicesInput) . '</error>');
+                return false;
+            }
+        } elseif ($typeInput = ArrayArgument::getOption($input, 'type')) {
+            $byType = [];
+            foreach ($allServices as $name => $service) {
+                $type = $service->type;
+                list($prefix) = explode(':', $service->type, 2);
+                $byType[$type][] = $name;
+                $byType[$prefix][] = $name;
+            }
+            $selectedKeys = Wildcard::select(array_merge(array_keys($byType), ['router']), $typeInput);
+            if (!$selectedKeys) {
+                $this->stdErr->writeln('No services were found matching the type(s): <error>' . implode(', ', $typeInput) . '</error>');
+                return false;
+            }
+            foreach ($selectedKeys as $selectedKey) {
+                $selectedServiceNames = array_merge($selectedServiceNames, $byType[$selectedKey]);
+            }
+            $selectedServiceNames = array_unique($selectedServiceNames);
+        }
+        if (!empty($selectedServiceNames)) {
+            $this->debug('Selected service(s): ' . implode(', ', $selectedServiceNames));
+            if (count($selectedServiceNames) === 1) {
+                $query->addFilter('service', reset($selectedServiceNames));
+            }
+        }
+
+        if ($this->stdErr->isDebug()) {
+            $this->debug('Metrics query: ' . json_encode($query->asArray(), JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES));
+        }
+
+        // Perform the metrics query.
+        $client = $this->api()->getHttpClient();
+        $request = $client->createRequest('POST', $metricsQueryUrl, ['json' => $query->asArray()]);
+        try {
+            $result = $client->send($request);
+        } catch (BadResponseException $e) {
+            throw ApiResponseException::create($request, $e->getResponse(), $e);
+        }
+
+        // Decode the response.
+        $content = $result->getBody()->__toString();
+        $items = JsonLines::decode($content);
+        if (empty($items)) {
+            $this->stdErr->writeln('No data points found.');
+            return false;
+        }
+
+        // Group the returned values by time, service, dimension, and field name.
+        // Filter by the selected services.
+        $values = [];
+        foreach ($items as $item) {
+            $time = $item['point']['timestamp'];
+            $dimension = isset($item['point']['dimension']) ? $item['point']['dimension'] : '';
+            $dimensionFields = $this->dimensionFields($dimension);
+            $service = $dimensionFields['service'];
+            // Skip the router service by default (if no services are selected).
+            if (empty($servicesInput) && $service === 'router') {
+                continue;
+            }
+            if (!empty($selectedServiceNames) && !in_array($service, $selectedServiceNames, true)) {
+                continue;
+            }
+            $fieldPrefix = $dimensionFields['mountpoint'] === '/tmp' ? 'tmp_' : '';
+            foreach ($item['point']['values'] as $value) {
+                $name = $value['info']['name'];
+                if (isset($values[$time][$service][$dimension][$fieldPrefix . $name])) {
+                    $this->stdErr->writeln(\sprintf(
+                        '<comment>Warning:</comment> duplicate value found for time %s, service %s, dimension %s, field %s',
+                        $time, $service, $dimension, $fieldPrefix . $name
+                    ));
+                } else {
+                    $values[$time][$service][$dimension][$fieldPrefix . $name] = Sketch::fromApiValue($value);
+                }
+            }
+        }
+
+        // Filter to only the latest timestamp if --latest is given.
+        if ($input->getOption('latest')) {
+            \ksort($values, SORT_NATURAL);
+            $values = \array_slice($values, -1, null, true);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Validates the interval and range input, and finds defaults.
+     *
+     * Sets the startTime, endTime, and interval properties.
+     *
+     * @see self::startTime, self::$endTime, self::$interval
+     *
+     * @param InputInterface $input
+     *
+     * @return TimeSpec|false
+     */
+    protected function validateTimeInput(InputInterface $input)
+    {
+        $interval = null;
+        if ($intervalStr = $input->getOption('interval')) {
+            $duration = new Duration();
+            $interval = $duration->toSeconds($intervalStr);
+            if (empty($interval)) {
+                $this->stdErr->writeln('Invalid --interval: <error>' . $intervalStr . '</error>');
+                return false;
+            } elseif ($interval < self::MIN_INTERVAL) {
+                $this->stdErr->writeln(\sprintf('The --interval <error>%s</error> is too short: it must be at least %d seconds.', $intervalStr, self::MIN_INTERVAL));
+                return false;
+            } elseif ($interval > self::MAX_INTERVAL) {
+                $this->stdErr->writeln(\sprintf('The --interval <error>%s</error> is too long: it must be %d seconds or less.', $intervalStr, self::MAX_INTERVAL));
+                return false;
+            }
+            $interval = \intval($interval);
+        }
+
+        if ($to = $input->getOption('to')) {
+            $endTime = \strtotime($to);
+            if (!$endTime) {
+                $this->stdErr->writeln('Failed to parse --to time: ' . $to);
+                return false;
+            }
+        } else {
+            $endTime = time();
+        }
+        if ($rangeStr = $input->getOption('range')) {
+            $rangeSeconds = (new Duration())->toSeconds($rangeStr);
+            if (empty($rangeSeconds)) {
+                $this->stdErr->writeln('Invalid --range: <error>' . $rangeStr . '</error>');
+                return false;
+            } elseif ($rangeSeconds < self::MIN_RANGE) {
+                $this->stdErr->writeln(\sprintf('The --range <error>%s</error> is too short: it must be at least %d seconds (%s).', $rangeStr, self::MIN_RANGE, (new Duration())->humanize(self::MIN_RANGE)));
+                return false;
+            }
+            $rangeSeconds = \intval($rangeSeconds);
+        } else {
+            $rangeSeconds = self::DEFAULT_RANGE;
+        }
+
+        if ($interval === null) {
+            $interval = $this->defaultInterval($rangeSeconds);
+        }
+
+        if ($input->getOption('latest')) {
+            $rangeSeconds = $interval;
+        }
+
+        $startTime = $endTime - $rangeSeconds;
+
+        return new TimeSpec($startTime, $endTime, $interval);
+    }
+
+    /**
+     * Determines a default interval based on the range.
+     *
+     * @param int $range The range in seconds.
+     *
+     * @return int
+     */
+    private function defaultInterval($range)
+    {
+        $divisor = 5; // Number of points per time range.
+        $granularity = 10; // Number of seconds to round to.
+        $interval = \round($range / ($divisor * $granularity)) * $granularity;
+        if ($interval <= self::MIN_INTERVAL) {
+            return self::MIN_INTERVAL;
+        }
+        if ($interval >= self::MAX_INTERVAL) {
+            return self::MAX_INTERVAL;
+        }
+        return (int) $interval;
+    }
+
+    /**
+     * Returns the deployment type of an environment (needed for differing queries).
+     *
+     * @param Environment $environment
+     * @return string
+     */
+    private function getDeploymentType(Environment $environment)
+    {
+        if (isset($environmentData['embedded']['deployments'][0]['type'])) {
+            return $environmentData['embedded']['deployments'][0]['type'];
+        }
+        if (in_array($environment->deployment_target, ['local', 'enterprise', 'dedicated'])) {
+            return $environment->deployment_target;
+        }
+        throw new \RuntimeException('Failed to determine the deployment type');
+    }
+
+    /**
+     * Builds metrics table rows.
+     *
+     * @param array $values
+     *   An array of values from fetchMetrics().
+     * @param array<string, Field> $fields
+     *   An array of fields keyed by column name.
+     *
+     * @return array
+     *   Table rows.
+     */
+    protected function buildRows(array $values, $fields)
+    {
+        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
+        $formatter = $this->getService('property_formatter');
+
+        $deployment = $this->api()->getCurrentDeployment($this->getSelectedEnvironment());
+
+        // Create a closure which can sort services by name, putting apps and
+        // workers first.
+        $appAndWorkerNames = array_keys(array_merge($deployment->webapps, $deployment->workers));
+        sort($appAndWorkerNames, SORT_NATURAL);
+        $serviceNames = array_keys($deployment->services);
+        sort($serviceNames, SORT_NATURAL);
+        $nameOrder = array_flip(array_merge($appAndWorkerNames, $serviceNames, ['router']));
+        $sortServices = function ($a, $b) use ($nameOrder) {
+            $aPos = isset($nameOrder[$a]) ? $nameOrder[$a] : 1000;
+            $bPos = isset($nameOrder[$b]) ? $nameOrder[$b] : 1000;
+            return $aPos > $bPos ? 1 : ($aPos < $bPos ? -1 : 0);
+        };
+
+        $rows = [];
+        $lastCountPerTimestamp = 0;
+        foreach ($values as $timestamp => $byService) {
+            // Add a separator if there was more than one row for the previous timestamp.
+            if ($lastCountPerTimestamp > 1) {
+                $rows[] = new TableSeparator();
+            }
+            $startCount = count($rows);
+            $formattedTimestamp = $formatter->formatDate($timestamp);
+            uksort($byService, $sortServices);
+            foreach ($byService as $service => $byDimension) {
+                if (isset($deployment->services[$service])) {
+                    $type = $deployment->services[$service]->type;
+                } elseif (isset($deployment->webapps[$service])) {
+                    $type = $deployment->webapps[$service]->type;
+                } elseif (isset($deployment->workers[$service])) {
+                    $type = $deployment->workers[$service]->type;
+                } else {
+                    $type = '';
+                }
+
+                $serviceRows = [];
+                foreach ($byDimension as $values) {
+                    $row = [];
+                    $row['timestamp'] = new AdaptiveTableCell($formattedTimestamp, ['wrap' => false]);
+                    $row['service'] = $service;
+                    $row['type'] = $type;
+                    foreach ($fields as $columnName => $field) {
+                        /** @var Field $field */
+                        $fieldName = $field->getName();
+                        if (isset($values[$fieldName])) {
+                            /** @var Sketch $value */
+                            $value = $values[$fieldName];
+                            if ($fieldName === 'mem_percent' && isset($deployment->services[$service])) {
+                                if ($value->average() > 90) {
+                                    $this->foundHighMemoryServices = true;
+                                }
+                                $row[$columnName] = $field->format($values[$fieldName], false);
+                            } elseif ($fieldName === 'mem_limit' && $service === 'router' && $value->average() == 0) {
+                                $row[$columnName] = '';
+                            } elseif ($fieldName === 'mem_percent' && $service === 'router' && $value->isInfinite()) {
+                                $row[$columnName] = '';
+                            } else {
+                                $row[$columnName] = $field->format($values[$fieldName]);
+                            }
+                        }
+                    }
+                    $serviceRows[] = $row;
+                }
+                $rows = array_merge($rows, $this->mergeRows($serviceRows));
+            }
+            $lastCountPerTimestamp = count($rows) - $startCount;
+        }
+        return $rows;
+    }
+
+    /**
+     * Merges table rows per service to reduce unnecessary empty cells.
+     *
+     * @param array $rows
+     * @return array
+     */
+    private function mergeRows(array $rows)
+    {
+        $infoKeys = array_flip(['service', 'timestamp', 'instance', 'type']);
+        $previous = $previousKey = null;
+        foreach (array_keys($rows) as $key) {
+            // Merge rows if they do not have any keys in common except for
+            // $infoKeys, and if their values are the same for those keys.
+            if ($previous !== null
+                && !array_intersect_key(array_diff_key($rows[$key], $infoKeys), array_diff_key($previous, $infoKeys))
+                && array_intersect_key($rows[$key], $infoKeys) == array_intersect_key($previous, $infoKeys)) {
+                $rows[$key] += $previous;
+                unset($rows[$previousKey]);
+            }
+            $previous = $rows[$key];
+            $previousKey = $key;
+        }
+        return $rows;
+    }
+
+    /**
+     * Displays the current project and environment, if not already displayed.
+     *
+     * @return void
+     */
+    protected function displayEnvironmentHeader()
+    {
+        if (!$this->printedSelectedEnvironment) {
+            $this->stdErr->writeln('Selected project: ' . $this->api()->getProjectLabel($this->getSelectedProject()));
+            $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->getSelectedEnvironment()));
+        }
+        $this->stdErr->writeln('');
+    }
+
+    /**
+     * Shows an explanation if services were found that use high memory.
+     *
+     * @return void
+     */
+    protected function explainHighMemoryServices()
+    {
+        if ($this->foundHighMemoryServices) {
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln('<comment>Note:</comment> it is possible for service memory usage to appear high even in normal circumstances.');
+        }
+    }
+}

--- a/src/Model/Metrics/Field.php
+++ b/src/Model/Metrics/Field.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Platformsh\Cli\Model\Metrics;
+
+use Symfony\Component\Console\Helper\FormatterHelper;
+
+class Field
+{
+    const RED_WARNING_THRESHOLD = 90; // percent
+    const YELLOW_WARNING_THRESHOLD = 80; // percent
+
+    const FORMAT_ROUNDED = 'rounded';
+    const FORMAT_ROUNDED_2DP = 'rounded_2';
+    const FORMAT_PERCENT = 'percent';
+    const FORMAT_DISK = 'disk';
+    const FORMAT_MEMORY = 'memory';
+
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $format;
+
+    public function __construct($name, $format)
+    {
+        $this->name = $name;
+        $this->format = $format;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Formats a float as a percentage.
+     *
+     * @param float $pc
+     * @param bool $warn
+     *
+     * @return string
+     */
+    private function formatPercent($pc, $warn = true)
+    {
+        if ($warn) {
+            if ($pc >= self::RED_WARNING_THRESHOLD) {
+                return \sprintf('<options=bold;fg=red>%.1f%%</>', $pc);
+            }
+            if ($pc >= self::YELLOW_WARNING_THRESHOLD) {
+                return \sprintf('<options=bold;fg=yellow>%.1f%%</>', $pc);
+            }
+        }
+        return \sprintf('%.1f%%', $pc);
+    }
+
+    /**
+     * Formats a value according to the field format.
+     *
+     * @param Sketch $value
+     * @param bool $warn
+     *   Adds colors if the value is over a threshold.
+     *
+     * @return string
+     */
+    public function format(Sketch $value, $warn = true)
+    {
+        if ($value->isInfinite()) {
+            return '∞';
+        }
+        switch ($this->format) {
+            case self::FORMAT_ROUNDED:
+                return (string) round($value->average());
+            case self::FORMAT_ROUNDED_2DP:
+                return (string) round($value->average(), 2);
+            case self::FORMAT_PERCENT:
+                return $this->formatPercent($value->average(), $warn);
+            case self::FORMAT_DISK:
+            case self::FORMAT_MEMORY:
+                return FormatterHelper::formatMemory($value->average());
+        }
+        throw new \InvalidArgumentException('Formatter not found: ' . $this->format);
+    }
+}

--- a/src/Model/Metrics/Query.php
+++ b/src/Model/Metrics/Query.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Platformsh\Cli\Model\Metrics;
+
+/**
+ * Represents a Metrics API query.
+ */
+class Query
+{
+    /** @var int Interval in seconds */
+    private $interval;
+    /** @var int Start timestamp */
+    private $startTime;
+    /** @var int End timestamp */
+    private $endTime;
+    /** @var string */
+    private $collection;
+    /** @var array */
+    private $fields = [];
+    /** @var array */
+    private $filters = [];
+
+    /**
+     * @param int $interval
+     * @return Query
+     */
+    public function setInterval($interval)
+    {
+        $this->interval = $interval;
+        return $this;
+    }
+
+    /**
+     * @param int $startTime
+     * @return Query
+     */
+    public function setStartTime($startTime)
+    {
+        $this->startTime = $startTime;
+        return $this;
+    }
+
+    /**
+     * @param int $endTime
+     * @return Query
+     */
+    public function setEndTime($endTime)
+    {
+        $this->endTime = $endTime;
+        return $this;
+    }
+
+    /**
+     * @param string $collection
+     * @return Query
+     */
+    public function setCollection($collection)
+    {
+        $this->collection = $collection;
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param string $expression
+     * @return Query
+     */
+    public function addField($name, $expression)
+    {
+        $this->fields[$name] = $expression;
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @return Query
+     */
+    public function addFilter($key, $value)
+    {
+        $this->filters[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Returns the query as an array.
+     * @return array
+     */
+    public function asArray()
+    {
+        $query = [
+            'stream' => [
+                'stream' => 'metrics',
+                'collection' => $this->collection,
+            ],
+            'interval' => $this->interval . 's',
+            'fields' => [],
+            'range' => [
+                'from' => date('Y-m-d\TH:i:s.uP', $this->startTime),
+                'to' => date('Y-m-d\TH:i:s.uP', $this->endTime),
+            ],
+        ];
+        foreach ($this->fields as $name => $expr) {
+            $query['fields'][] = ['name' => $name, 'expr' => $expr];
+        }
+        foreach ($this->filters as $key => $value) {
+            $query['filters'][] = ['key' => $key, 'value' => $value];
+        }
+        return $query;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEndTime()
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+
+}

--- a/src/Model/Metrics/Sketch.php
+++ b/src/Model/Metrics/Sketch.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Platformsh\Cli\Model\Metrics;
+
+class Sketch
+{
+    /** @var string|int|float */
+    private $sum;
+
+    /** @var string|int|float */
+    private $count;
+
+    /** @var string */
+    private $name;
+
+    /**
+     * @param array $value
+     * @return Sketch
+     */
+    public static function fromApiValue(array $value)
+    {
+        $s = new Sketch();
+        $s->name = $value['info']['name'];
+        $s->count = isset($value['value']['count']) ? $value['value']['count'] : 1;
+        $s->sum = isset($value['value']['sum']) ? $value['value']['sum'] : 0;
+        return $s;
+    }
+
+    /**
+     * @return string
+     */
+    public function name()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInfinite()
+    {
+        return $this->sum === 'Infinity' || $this->count === 'Infinity';
+    }
+
+    /**
+     * @return float
+     */
+    public function average()
+    {
+        if ($this->isInfinite()) {
+            throw new \RuntimeException('Cannot find the average of an infinite value');
+        }
+        return $this->sum / (float) $this->count;
+    }
+}

--- a/src/Model/Metrics/TimeSpec.php
+++ b/src/Model/Metrics/TimeSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Platformsh\Cli\Model\Metrics;
+
+class TimeSpec
+{
+    private $startTime;
+    private $endTime;
+    private $interval;
+
+    /**
+     * @param int $startTime Start time (UNIX timestamp).
+     * @param int $endTime End time (UNIX timestamp).
+     * @param int $interval Interval (seconds).
+     */
+    public function __construct($startTime, $endTime, $interval)
+    {
+        $this->startTime = $startTime;
+        $this->endTime = $endTime;
+        $this->interval = $interval;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEndTime()
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInterval()
+    {
+        return $this->interval;
+    }
+}


### PR DESCRIPTION
This adds support for:

* Reading CPU and memory metrics (and all metrics at once in the `metrics` command).
* Viewing metrics for all services at once.
* Viewing temporary disk usage (as well as persistent).
* A `metrics:curl` command to help debug the API for an environment's metrics (intended for internal use; hidden from the command list).

It also changes the output of the `disk` command, which could require updates to scripts for compatibility:

* New *default* columns "Service" (service) and "/tmp %" (tmp_percent). The default columns are now: timestamp, service, used, limit, percent, ipercent, and tmp_percent.
* The command reports data for multiple services by default, if no --service (-s) option is given.
* The --type and --service options can support selecting multiple services with a wildcard or providing multiple arguments.
* If there are multiple data points per timestamp (if multiple services are displayed), the rows are separated with dashes.
* Other columns relating to temporary disks are available (tmp_used, tmp_limit, etc.). See the command help for more information.