### PR TITLE
Only check for updates if the containing directory is writable

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -393,8 +393,8 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             return;
         }
 
-        // Check if the file is writable.
-        if (!is_writable($pharFilename)) {
+        // Check if the file and its containing directory are writable.
+        if (!is_writable($pharFilename) || !is_writable(dirname($pharFilename))) {
             return;
         }
 

--- a/src/Service/SelfUpdater.php
+++ b/src/Service/SelfUpdater.php
@@ -115,6 +115,11 @@ class SelfUpdater
 
             return false;
         }
+        if (!is_writable(dirname($localPhar))) {
+            $this->stdErr->writeln('Cannot update as the directory is not writable: ' . dirname($localPhar));
+
+            return false;
+        }
 
         $updater = new Updater($localPhar, false);
         $strategy = new ManifestStrategy(ltrim($currentVersion, 'v'), $manifestUrl, $this->allowMajor, $this->allowUnstable);


### PR DESCRIPTION
Addresses #1276 in the sense that automatically checking for updates requires the phar's directory to be writable, which is a workaround because of how the humbug/phar-updater library works:
https://github.com/humbug/phar-updater/blob/e5a5da3dc3344031271157c7f10b0fa04afffa9b/src/Updater.php#L467-L470

Ideally updating is now intended to be via the newer [wrapper](https://github.com/platformsh/cli) and package management, etc.