### PR TITLE
Allow "." to select the default environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.71.2 <2.0",
+        "platformsh/client": ">=0.71.3 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a907a5aff9d4f7c63210c017c881dc00",
+    "content-hash": "caaabaa19151ec64dc15b83441bba9e4",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -918,16 +918,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.71.2",
+            "version": "0.71.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "52d61104287cd4256aea4ca195f6169afca987e1"
+                "reference": "86cf9139869b7c7269a909b77dccd69f13ff9b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/52d61104287cd4256aea4ca195f6169afca987e1",
-                "reference": "52d61104287cd4256aea4ca195f6169afca987e1",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/86cf9139869b7c7269a909b77dccd69f13ff9b94",
+                "reference": "86cf9139869b7c7269a909b77dccd69f13ff9b94",
                 "shasum": ""
             },
             "require": {
@@ -959,9 +959,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.71.2"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.71.3"
             },
-            "time": "2023-07-13T10:03:42+00:00"
+            "time": "2023-07-17T11:23:05+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -249,7 +249,7 @@ class CompletionCommand extends ParentCompletionCommand
                 }
             }
         } elseif ($project = $this->getProject()) {
-            if ($environment = $this->api->getDefaultEnvironment($project, false)) {
+            if ($environment = $this->api->getDefaultEnvironment($project, false, false)) {
                 $apps = array_keys($environment->getSshUrls());
             }
         }

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1221,17 +1221,26 @@ class Api
     }
 
     /**
-     * Get the default environment in a project.
+     * Returns a default environment for a project.
+     *
+     * This may be the one set as the project's default_branch, or another
+     * environment, e.g. if the user only has access to 1 environment.
      *
      * @param Project   $project
+     * @param bool $onlyDefaultBranch Only use the default_branch.
      * @param bool|null $refresh
      *
      * @return Environment|null
      */
-    public function getDefaultEnvironment(Project $project, $refresh = null)
+    public function getDefaultEnvironment(Project $project, $onlyDefaultBranch = false, $refresh = null)
     {
+        if ($project->default_branch === '') {
+            throw new \RuntimeException('Default branch not set');
+        }
         if ($env = $this->getEnvironment($project->default_branch, $project, $refresh)) {
             return $env;
+        } elseif ($onlyDefaultBranch) {
+            return null;
         }
         $envs = $this->getEnvironments($project, $refresh);
 


### PR DESCRIPTION
This provides

```sh
-e .
```

as a shortcut for

```sh
-e "$(platform project:info default_branch)"
```

And it prevents looking up a resource (like an environment) with the ID "." or "..", which should not be considered valid, but currently selects the collection (e.g. the environments list) or the parent resource (e.g. the project) respectively.