### PR TITLE
Add more composer package checks to isDrupal

### DIFF
--- a/src/Local/BuildFlavor/Drupal.php
+++ b/src/Local/BuildFlavor/Drupal.php
@@ -73,7 +73,10 @@ class Drupal extends BuildFlavorBase
         foreach ($finder as $file) {
             $composerJson = json_decode(file_get_contents($file), true);
             if (isset($composerJson['require']['drupal/core'])
-                || isset($composerJson['require']['drupal/phing-drush-task'])) {
+                || isset($composerJson['require']['drupal/core-recommended'])
+                || isset($composerJson['require']['drupal/drupal'])
+                || isset($composerJson['require']['drupal/phing-drush-task'])
+            ) {
                 return true;
             }
         }


### PR DESCRIPTION
Adds a few more composer package checks to `isDrupal` to try to increase recognition of a Drupal app.