### PR TITLE
Improve SSH argument quoting

### DIFF
--- a/src/Command/Environment/EnvironmentScpCommand.php
+++ b/src/Command/Environment/EnvironmentScpCommand.php
@@ -51,7 +51,7 @@ class EnvironmentScpCommand extends CommandBase
         $command = 'scp';
 
         if ($sshArgs = $ssh->getSshArgs()) {
-            $command .= ' ' . implode(' ', array_map([OsUtil::class, 'escapeShellArg'], $sshArgs));
+            $command .= ' ' . implode(' ', array_map([OsUtil::class, 'escapePosixShellArg'], $sshArgs));
         }
 
         if ($input->getOption('recursive')) {

--- a/src/Command/Environment/EnvironmentSshCommand.php
+++ b/src/Command/Environment/EnvironmentSshCommand.php
@@ -67,10 +67,7 @@ class EnvironmentSshCommand extends CommandBase
         }
 
         $remoteCommand = $input->getArgument('cmd');
-        if (is_array($remoteCommand)) {
-            $remoteCommand = implode(' ', $remoteCommand);
-        }
-        if (!$remoteCommand && $this->runningViaMulti) {
+        if (empty($remoteCommand) && $this->runningViaMulti) {
             throw new InvalidArgumentException('The cmd argument is required when running via "multi"');
         }
 

--- a/src/Model/Host/RemoteHost.php
+++ b/src/Model/Host/RemoteHost.php
@@ -66,7 +66,7 @@ class RemoteHost implements HostInterface
     private function wrapCommandLine($commandLine)
     {
         return $this->sshService->getSshCommand()
-            . ($this->extraSshArgs ? ' ' . implode(' ', array_map([OsUtil::class, 'escapeShellArg'], $this->extraSshArgs)) : '')
+            . ($this->extraSshArgs ? ' ' . implode(' ', array_map([OsUtil::class, 'escapePosixShellArg'], $this->extraSshArgs)) : '')
             . ' ' . escapeshellarg($this->sshUrl)
             . ' ' . escapeshellarg($commandLine);
     }

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -43,7 +43,7 @@ class Ssh implements InputConfiguringInterface
      *
      * @param array $extraOptions
      * @param string|null $uri
-     * @param string|null $remoteCommand
+     * @param string[]|string|null $remoteCommand
      *
      * @return array
      */
@@ -67,8 +67,12 @@ class Ssh implements InputConfiguringInterface
         if ($uri !== null) {
             $args[] = $uri;
         }
-        if ($remoteCommand !== null) {
-            $args[] = $remoteCommand;
+        if (!empty($remoteCommand)) {
+            if (is_array($remoteCommand)) {
+                $args[] = $this->argsToString($remoteCommand);
+            } else {
+                $args[] = $remoteCommand;
+            }
         }
 
         return $args;
@@ -161,9 +165,14 @@ class Ssh implements InputConfiguringInterface
         $command = 'ssh';
         $args = $this->getSshArgs($extraOptions, $uri, $remoteCommand);
         if (!empty($args)) {
-            $command .= ' ' . implode(' ', array_map([OsUtil::class, 'escapeShellArg'], $args));
+            $command .= ' ' . $this->argsToString($args);
         }
 
         return $command;
+    }
+
+    private function argsToString(array $args)
+    {
+        return implode(' ', array_map([OsUtil::class, 'escapePosixShellArg'], $args));
     }
 }


### PR DESCRIPTION
A command with multiple arguments can be provided to `platform ssh` via `--`

```sh
platform ssh -- sed -n '/20\/Jul\/2023\:09\:40/, /20\/Jul\/2023\:09\:45/p' /var/log/access.log
```

Currently this is incorrectly quoted when forwarded over SSH