### PR TITLE
Improve activity log formatting

### DIFF
--- a/src/Command/Activity/ActivityCancelCommand.php
+++ b/src/Command/Activity/ActivityCancelCommand.php
@@ -96,11 +96,7 @@ class ActivityCancelCommand extends ActivityCommandBase
             $activity = $byId[$id];
         }
 
-        $this->stdErr->writeln(sprintf(
-            'Cancelling the activity <info>%s</info> (%s)...',
-            $activity->id,
-            ActivityMonitor::getFormattedDescription($activity)
-        ));
+        $this->stdErr->writeln('Cancelling the activity ' . ActivityMonitor::getFormattedDescription($activity, true, true, 'cyan'));
 
         try {
             $activity->cancel();

--- a/src/Command/Environment/EnvironmentResumeCommand.php
+++ b/src/Command/Environment/EnvironmentResumeCommand.php
@@ -39,7 +39,6 @@ class EnvironmentResumeCommand extends CommandBase
         if (!$questionHelper->confirm('Are you sure you want to resume the paused environment <comment>' . $environment->id . '</comment>?')) {
             return 1;
         }
-        $this->stdErr->writeln('');
 
         $activity = $environment->resume();
         $this->api()->clearEnvironmentsCache($environment->project);


### PR DESCRIPTION
- Prioritize displaying the log if there is one non-integration activity
- Add a newline before waiting
- Standardize how activity descriptions are displayed