### PR TITLE
Improve dev domains support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -274,10 +274,9 @@ warnings:
 
   # The message shown when trying to add non-production domains to a project
   # without the capability.
-  # TODO update this when the feature is no longer in beta.
   non_production_domains_msg: |
-    This feature is only available to Enterprise and Elite customers and is currently in beta.
-    If you're an Enterprise or Elite customer, contact support to become a beta tester.
+    This feature is only available to Enterprise and Elite customers.
+    If you're an Enterprise or Elite customer, contact support to enable the feature.
     Otherwise contact sales first to upgrade your plan.
 
     See: https://docs.platform.sh/overview/get-support.html

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1622,7 +1622,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             $this->selectEnvironment($environmentId, !$envNotRequired, $selectDefaultEnv, $detectCurrent);
         }
 
-        if ($this->stdErr->isVerbose() && $this->environment && !$this->printedSelectedEnvironment) {
+        if ($this->stdErr->isVerbose() && $this->environment) {
             $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->environment));
             $this->printedSelectedEnvironment = true;
         }

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -84,6 +84,13 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     protected $runningViaMulti = false;
 
     /**
+     * Whether the selected project has been printed (e.g. via verbose output).
+     *
+     * @var bool
+     */
+    protected $printedSelectedProject = false;
+
+    /**
      * Whether the selected environment has been printed (e.g. via verbose output).
      *
      * @var bool
@@ -1587,6 +1594,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         $project = $this->selectProject($projectId, $projectHost, $detectCurrent);
         if ($this->stdErr->isVerbose()) {
             $this->stdErr->writeln('Selected project: ' . $this->api()->getProjectLabel($project));
+            $this->printedSelectedProject = true;
         }
 
         // Select the environment.
@@ -1622,9 +1630,41 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             $this->selectEnvironment($environmentId, !$envNotRequired, $selectDefaultEnv, $detectCurrent);
         }
 
-        if ($this->stdErr->isVerbose() && $this->environment) {
+        if ($this->stdErr->isVerbose()) {
+            $this->ensurePrintSelectedEnvironment();
+        }
+    }
+
+    /**
+     * Prints the selected project, if it has not already been printed.
+     *
+     * @param bool $blankLine Append an extra newline after the message, if any is printed.
+     */
+    private function ensurePrintSelectedProject($blankLine = false) {
+        if (!$this->printedSelectedProject && $this->project) {
+            $this->stdErr->writeln('Selected project: ' . $this->api()->getProjectLabel($this->project));
+            $this->printedSelectedProject = true;
+            if ($blankLine) {
+                $this->stdErr->writeln('');
+            }
+        }
+    }
+
+    /**
+     * Prints the selected environment, if it has not already been printed.
+     *
+     * Also prints the selected project if necessary.
+     *
+     * @param bool $blankLine Append an extra newline after the message, if any is printed.
+     */
+    protected function ensurePrintSelectedEnvironment($blankLine = false) {
+        if (!$this->printedSelectedEnvironment && $this->environment) {
+            $this->ensurePrintSelectedProject();
             $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->environment));
             $this->printedSelectedEnvironment = true;
+            if ($blankLine) {
+                $this->stdErr->writeln('');
+            }
         }
     }
 
@@ -2187,7 +2227,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
 
         if ($input->hasOption('project') && ($id = $input->getOption('project'))) {
             $project = $this->selectProject($id);
-            $this->stdErr->writeln(\sprintf('Selected project: %s', $this->api()->getProjectLabel($project)));
+            $this->ensurePrintSelectedProject();
             $organization = $client->getOrganizationById($project->getProperty('organization'));
             if ($organization) {
                 $this->stdErr->writeln(\sprintf('Project organization: %s', $this->api()->getOrganizationLabel($organization)));
@@ -2203,7 +2243,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             }
             if ($organization) {
                 if ($this->stdErr->isVerbose()) {
-                    $this->stdErr->writeln(\sprintf('Selected project: %s', $this->api()->getProjectLabel($currentProject)));
+                    $this->ensurePrintSelectedProject();
                     $this->stdErr->writeln(\sprintf('Project organization: %s', $this->api()->getOrganizationLabel($organization)));
                 }
                 return $organization;

--- a/src/Command/Domain/DomainAddCommand.php
+++ b/src/Command/Domain/DomainAddCommand.php
@@ -19,7 +19,8 @@ class DomainAddCommand extends DomainCommandBase
             ->setName('domain:add')
             ->setDescription('Add a new domain to the project');
         $this->addDomainOptions();
-        $this->addOption('replace', 'r', InputOption::VALUE_REQUIRED, "The production domain which this one replaces in the environment's routes (required for non-production environment domains)");
+        $this->addOption('attach', null, InputOption::VALUE_REQUIRED, "The production domain that this one replaces in the environment's routes. Required for non-production environment domains.");
+        $this->addHiddenOption('replace', 'r', InputOption::VALUE_REQUIRED, 'Deprecated: this has been renamed to --attach');
         $this->addProjectOption()
             ->addEnvironmentOption()
             ->addWaitOptions();
@@ -35,6 +36,8 @@ class DomainAddCommand extends DomainCommandBase
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->warnAboutDeprecatedOptions(['replace'], 'The option --replace has been renamed to --attach.');
+
         $this->validateInput($input, true);
 
         if (!$this->validateDomainInput($input)) {
@@ -48,8 +51,8 @@ class DomainAddCommand extends DomainCommandBase
         $environment = $this->getSelectedEnvironment();
 
         $this->stdErr->writeln(sprintf('Adding the domain <info>%s</info> to the environment %s.', $this->domainName, $this->api()->getEnvironmentLabel($environment)));
-        if (!empty($this->replacementFor)) {
-            $this->stdErr->writeln(sprintf('The domain will replace the production domain <info>%s</info>', $this->replacementFor));
+        if (!empty($this->attach)) {
+            $this->stdErr->writeln(sprintf('The domain will be attached to the production domain <info>%s</info>', $this->attach));
         }
         $this->stdErr->writeln('');
         if (!$questionHelper->confirm('Are you sure you want to continue?')) {
@@ -58,7 +61,7 @@ class DomainAddCommand extends DomainCommandBase
 
         $httpClient = $this->api()->getHttpClient();
         try {
-            $result = EnvironmentDomain::add($httpClient, $environment, $this->domainName, $this->replacementFor, $this->sslOptions);
+            $result = EnvironmentDomain::add($httpClient, $environment, $this->domainName, $this->attach, $this->sslOptions);
         } catch (ClientException $e) {
             $response = $e->getResponse();
             if ($response) {
@@ -79,7 +82,7 @@ class DomainAddCommand extends DomainCommandBase
                     if (isset($data['message'], $data['detail']['conflicting_domain']) && strpos($data['message'], 'already has a domain with the same replacement_for') !== false) {
                         $this->stdErr->writeln('');
                         $this->stdErr->writeln(sprintf(
-                            'The environment %s already has a domain with the same <comment>--replace</comment> value: <error>%s</error>',
+                            'The environment %s already has a domain with the same <comment>--attach</comment> value: <error>%s</error>',
                             $this->api()->getEnvironmentLabel($environment, 'comment'), $data['detail']['conflicting_domain']
                         ));
                         return 1;
@@ -87,8 +90,8 @@ class DomainAddCommand extends DomainCommandBase
                     if (isset($data['message'], $data['detail']['prod-domains']) && strpos($data['message'], 'has no corresponding domain set on the production environment') !== false) {
                         $this->stdErr->writeln('');
                         $this->stdErr->writeln(sprintf(
-                            'The <comment>--replace</comment> domain does not exist on a production environment: <error>%s</error>',
-                            $this->replacementFor
+                            'The <comment>--attach</comment> domain does not exist on a production environment: <error>%s</error>',
+                            $this->attach
                         ));
                         if (!empty($data['detail']['prod-domains'])) {
                             $this->stdErr->writeln('');

--- a/src/Command/Domain/DomainAddCommand.php
+++ b/src/Command/Domain/DomainAddCommand.php
@@ -49,10 +49,11 @@ class DomainAddCommand extends DomainCommandBase
 
         $project = $this->getSelectedProject();
         $environment = $this->getSelectedEnvironment();
+        $this->ensurePrintSelectedEnvironment(true);
 
-        $this->stdErr->writeln(sprintf('Adding the domain <info>%s</info> to the environment %s.', $this->domainName, $this->api()->getEnvironmentLabel($environment)));
+        $this->stdErr->writeln(sprintf('Adding the domain: <info>%s</info>', $this->domainName));
         if (!empty($this->attach)) {
-            $this->stdErr->writeln(sprintf('The domain will be attached to the production domain <info>%s</info>', $this->attach));
+            $this->stdErr->writeln(sprintf('It will be attached to the production domain: <info>%s</info>', $this->attach));
         }
         $this->stdErr->writeln('');
         if (!$questionHelper->confirm('Are you sure you want to continue?')) {

--- a/src/Command/Domain/DomainCommandBase.php
+++ b/src/Command/Domain/DomainCommandBase.php
@@ -58,8 +58,7 @@ abstract class DomainCommandBase extends CommandBase
                 || ($input->hasOption('attach') && $input->getOption('attach') !== null)
                 || ($input->hasOption('replace') && $input->getOption('replace') !== null);
 
-            $capabilities = $project->getCapabilities();
-            $supportsNonProduction = !empty($capabilities->custom_domains['enabled']);
+            $supportsNonProduction = $this->supportsNonProductionDomains($project);
 
             if ($forEnvironment) {
                 $this->selectEnvironment($input->getOption('environment'), true, false, true, true);
@@ -212,5 +211,22 @@ abstract class DomainCommandBase extends CommandBase
             }
         }
         throw $e;
+    }
+
+    /**
+     * Checks if a project supports non-production domains.
+     *
+     * @param Project $project
+     *
+     * @return bool
+     */
+    protected function supportsNonProductionDomains(Project $project)
+    {
+        static $cache = [];
+        if (!isset($cache[$project->id])) {
+            $capabilities = $project->getCapabilities();
+            $cache[$project->id] = !empty($capabilities->custom_domains['enabled']);
+        }
+        return $cache[$project->id];
     }
 }

--- a/src/Command/Domain/DomainCommandBase.php
+++ b/src/Command/Domain/DomainCommandBase.php
@@ -119,12 +119,21 @@ abstract class DomainCommandBase extends CommandBase
                         $this->attach = $productionDomain->name;
                     } else {
                         $choices = [];
+                        $default = $project->getProperty('default_domain', false);
                         foreach ($productionDomains as $productionDomain) {
-                            $choices[$productionDomain->name] = $productionDomain->name;
+                            if ($productionDomain->name === $default) {
+                                $choices[$productionDomain->name] = $productionDomain->name . ' (default)';
+                            } else {
+                                $choices[$productionDomain->name] = $productionDomain->name;
+                            }
                         }
                         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
                         $questionHelper = $this->getService('question_helper');
-                        $this->attach = $questionHelper->choose($choices, "Choose a production domain for this one to replace in the environment's routes (<info>--attach</info>):", $project->getProperty('default_domain', false));
+                        $questionText = '<options=bold>Attachment</> (<info>--attach</info>)'
+                            . "\nA non-production domain must be attached to an existing production domain."
+                            . "\nIt will inherit the same routing behavior."
+                            . "\nChoose a production domain:";
+                        $this->attach = $questionHelper->choose($choices, $questionText, $default);
                     }
                 } elseif ($this->attach !== null) {
                     try {

--- a/src/Command/Domain/DomainCommandBase.php
+++ b/src/Command/Domain/DomainCommandBase.php
@@ -65,16 +65,13 @@ abstract class DomainCommandBase extends CommandBase
                 $this->selectEnvironment($input->getOption('environment'), true, false, true, true);
                 $environment = $this->getSelectedEnvironment();
                 $this->environmentIsProduction = $environment->id === $project->default_branch;
+                $this->ensurePrintSelectedEnvironment(true);
             } elseif ($project->default_branch === null) {
                 $this->stdErr->writeln('The <error>default_branch</error> property is not set on the project, so the production environment cannot be determined');
                 return false;
             } else {
                 $this->selectEnvironment($project->default_branch, true, false, false);
-                $environment = $this->getSelectedEnvironment();
                 $this->environmentIsProduction = true;
-                if ($this->stdErr->isVerbose()) {
-                    $this->stdErr->writeln(sprintf('Selected production environment %s by default', $this->api()->getEnvironmentLabel($environment, 'comment')));
-                }
                 if ($input->hasOption('attach') && $supportsNonProduction) {
                     $this->stdErr->writeln('Use the <comment>--environment</comment> option (and optionally <comment>--attach</comment>) to add a domain to a non-production environment.');
                     $this->stdErr->writeln('');
@@ -134,7 +131,7 @@ abstract class DomainCommandBase extends CommandBase
                         $domain = $project->getDomain($this->attach);
                         if ($domain === false) {
                             $this->stdErr->writeln(sprintf(
-                                'The <comment>--attach</comment> domain was not found: <error>%s</error>',
+                                'The production domain (<comment>--attach</comment>) was not found: <error>%s</error>',
                                 $this->attach
                             ));
                             return false;

--- a/src/Command/Domain/DomainListCommand.php
+++ b/src/Command/Domain/DomainListCommand.php
@@ -17,7 +17,7 @@ class DomainListCommand extends DomainCommandBase
         'created_at' => 'Creation date',
         'updated_at' => 'Updated date',
         'registered_name' => 'Registered name',
-        'replacement_for' => 'Replaces',
+        'replacement_for' => 'Attached domain',
         'type' => 'Type',
     ];
     private $defaultColumns = ['name', 'ssl', 'created_at'];
@@ -111,7 +111,7 @@ class DomainListCommand extends DomainCommandBase
                     ));
                 } else {
                     $this->stdErr->writeln(sprintf(
-                        'Add a domain to the environment by running <info>%s domain:add -e %s [domain-name] --replace [replace]</info>',
+                        'Add a domain to the environment by running <info>%s domain:add -e %s [domain-name] --attach [attach]</info>',
                         $executable,
                         OsUtil::escapeShellArg($environment->name)
                     ));
@@ -154,7 +154,7 @@ class DomainListCommand extends DomainCommandBase
             if ($forEnvironment) {
                 $exampleAddArgs = $exampleArgs = '-e ' . OsUtil::escapeShellArg($this->getSelectedEnvironment()->name) . ' [domain-name]';
                 if (!$this->getSelectedEnvironment()->is_main) {
-                    $exampleAddArgs .= ' -r [replace]';
+                    $exampleAddArgs .= ' --attach [attach]';
                 }
             } else {
                 $exampleAddArgs = $exampleArgs = '[domain-name]';

--- a/src/Model/EnvironmentDomain.php
+++ b/src/Model/EnvironmentDomain.php
@@ -35,7 +35,6 @@ class EnvironmentDomain extends Resource
     {
         $body = ['name' => $name];
         if (!empty($replacementFor)) {
-            $body['type'] = 'replacement';
             $body['replacement_for'] = $replacementFor;
         }
         if (!empty($ssl)) {


### PR DESCRIPTION
* Update for compatibility with project version 22 (omit the `type` parameter).
* Change `--replace` to `--attach`.
* Present an interactive choice of domains for `--attach` where relevant.
* Remove mention of "beta" in the messaging, when the feature for non-production environment domains is not enabled.
* Warn about attached domains when deleting a production domain.