### PR TITLE
Allow the push command to work before setting a remote project

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -274,6 +274,9 @@ api:
   # Whether the Metrics API is enabled.
   metrics: false
 
+  # Whether Git Push Options are enabled.
+  git_push_options: false
+
 # How the CLI detects and configures Git repositories as projects.
 detection:
   ## Required keys that must be defined elsewhere:

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -1630,7 +1630,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
      *
      * @param bool $blankLine Append an extra newline after the message, if any is printed.
      */
-    private function ensurePrintSelectedProject($blankLine = false) {
+    protected function ensurePrintSelectedProject($blankLine = false) {
         if (!$this->printedSelectedProject && $this->project) {
             $this->stdErr->writeln('Selected project: ' . $this->api()->getProjectLabel($this->project));
             $this->printedSelectedProject = true;
@@ -1648,7 +1648,11 @@ abstract class CommandBase extends Command implements MultiAwareInterface
      * @param bool $blankLine Append an extra newline after the message, if any is printed.
      */
     protected function ensurePrintSelectedEnvironment($blankLine = false) {
-        if (!$this->printedSelectedEnvironment && $this->environment) {
+        if (!$this->printedSelectedEnvironment) {
+            if (!$this->environment) {
+                $this->ensurePrintSelectedProject($blankLine);
+                return;
+            }
             $this->ensurePrintSelectedProject();
             $this->stdErr->writeln('Selected environment: ' . $this->api()->getEnvironmentLabel($this->environment));
             $this->printedSelectedEnvironment = true;

--- a/src/Exception/RootNotFoundException.php
+++ b/src/Exception/RootNotFoundException.php
@@ -15,9 +15,9 @@ class RootNotFoundException extends \RuntimeException
         // then suggest the "project:set-remote" command.
         if (is_dir('.git')) {
             $config = new Config();
-            if (is_dir($config->get('service.project_config_dir'))) {
+            if (is_dir($config->get('service.project_config_dir')) && $config->isCommandEnabled('project:set-remote')) {
                 $executable = $config->get('application.executable');
-                $message .= "\n\nTo set the project for this Git repository, run:\n  $executable project:set-remote [id]";
+                $message .= "\n\nTo set the project for this Git repository, run:\n  $executable set-remote [id]";
             }
         }
 


### PR DESCRIPTION
Improvements to the `push` command:
- Allow the current directory not to be mapped to a project - it need only be a Git repository.
- Also allow pushing to a different project (other than the one mapped to the directory).
- Only add or change the Git remote if `--set-upstream` is given. Recommend `set-remote` otherwise.
- State what will happen and then ask for confirmation before pushing in all interactive cases (not just when pushing to production).
- Use Git Push Options if available to activate the environment or set its parent (disabled by default).