### PR TITLE
Check the git push log for deployment errors

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -277,6 +277,9 @@ api:
   # Whether Git Push Options are enabled.
   git_push_options: false
 
+  # The timeout in seconds for a "git push" command. Set to null for no timeout.
+  git_push_timeout: 3600
+
 # How the CLI detects and configures Git repositories as projects.
 detection:
   ## Required keys that must be defined elsewhere:
@@ -297,6 +300,19 @@ detection:
   ## Dynamically defaults to the hostname of {service.console_url} if set.
   ##
   # console_domain: 'console.example.com'
+
+  # Messages from "git push" that should be considered as a deployment error.
+  #
+  # If one of these messages is found, the push command's exit code will be 87
+  # (non-zero, indicating failure).
+  push_deploy_error_messages:
+    - Environment creation failed
+    - Environment redeployment failed
+    - Error building project
+    - Unable to build application
+    - Unknown error building the application
+    - Unable to find stack
+    - Cannot build application of type
 
 # Pagination settings.
 #

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -295,18 +295,6 @@ class EnvironmentPushCommand extends CommandBase
             }
         }
 
-        // Clear the relationships cache if the environment was probably altered.
-        if ($targetEnvironment) {
-            try {
-                $sshUrl = $targetEnvironment->getSshUrl();
-                /** @var \Platformsh\Cli\Service\Relationships $relationships */
-                $relationships = $this->getService('relationships');
-                $relationships->clearCaches($sshUrl);
-            } catch (EnvironmentStateException $e) {
-                // Ignore environments with a missing SSH URL.
-            }
-        }
-
         // Advise the user to set the project as the remote.
         if (!$currentProject && !$input->getOption('set-upstream')) {
             $this->stdErr->writeln('');

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -3,7 +3,6 @@ namespace Platformsh\Cli\Command\Environment;
 
 use GuzzleHttp\Exception\BadResponseException;
 use Platformsh\Cli\Command\CommandBase;
-use Platformsh\Cli\Exception\ProcessFailedException;
 use Platformsh\Cli\Service\Ssh;
 use Platformsh\Cli\Util\OsUtil;
 use Platformsh\Client\Exception\EnvironmentStateException;
@@ -16,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentPushCommand extends CommandBase
 {
+    const PUSH_FAILURE_EXIT_CODE = 87;
 
     protected function configure()
     {
@@ -132,6 +132,7 @@ class EnvironmentPushCommand extends CommandBase
                     ? sprintf('Do you want to activate the target environment %s?', $this->api()->getEnvironmentLabel($targetEnvironment, 'info', false))
                     : sprintf('Create <info>%s</info> as an active environment?', $target);
                 $activateRequested = $questionHelper->confirm($questionText);
+                $this->stdErr->writeln('');
             }
             if ($activateRequested) {
                 // If activating, determine what the environment's parent should be.
@@ -147,8 +148,9 @@ class EnvironmentPushCommand extends CommandBase
                 } elseif ($type === null && $input->isInteractive()) {
                     $type = $this->askEnvironmentType($project);
                 }
+
+                $this->stdErr->writeln('');
             }
-            $this->stdErr->writeln('');
         }
 
         // Check if the environment may be a production one.
@@ -256,14 +258,31 @@ class EnvironmentPushCommand extends CommandBase
         }
         $git->setExtraSshOptions($extraSshOptions);
 
-        // Push.
-        try {
-            $git->execute($gitArgs, null, true, false, $env, true);
-        } catch (ProcessFailedException $e) {
+        // Perform the push, capturing the Process object so that the STDERR
+        // output can be read.
+        /** @var \Platformsh\Cli\Service\Shell $shell */
+        $shell = $this->getService('shell');
+        $process = $shell->executeCaptureProcess(\array_merge(['git'], $gitArgs), $gitRoot, false, false, $env + $git->setupSshEnv(), $this->config()->get('api.git_push_timeout'));
+        if ($process->getExitCode() !== 0) {
             /** @var \Platformsh\Cli\Service\SshDiagnostics $diagnostics */
             $diagnostics = $this->getService('ssh_diagnostics');
-            $diagnostics->diagnoseFailure($project->getGitUrl(), $e->getProcess());
-            return 1;
+            $diagnostics->diagnoseFailure($project->getGitUrl(), $process);
+            return $process->getExitCode();
+        }
+
+        // Clear the environment cache after pushing.
+        $this->api()->clearEnvironmentsCache($project->id);
+
+        // Check the push log for possible deployment error messages.
+        $log = $process->getErrorOutput();
+        $messages = $this->config()->getWithDefault('detection.push_deploy_error_messages', []);
+        foreach ($messages as $message) {
+            if (\strpos($log, $message) !== false) {
+                $this->stdErr->writeln('');
+                $this->stdErr->writeln(\sprintf('The "git push" completed but there was a deployment error ("<error>%s</error>").', $message));
+
+                return self::PUSH_FAILURE_EXIT_CODE;
+            }
         }
 
         // Wait if there are still activities.
@@ -276,11 +295,10 @@ class EnvironmentPushCommand extends CommandBase
             }
         }
 
-        // Clear some caches after pushing.
-        $this->api()->clearEnvironmentsCache($project->id);
-        if ($this->hasSelectedEnvironment()) {
+        // Clear the relationships cache if the environment was probably altered.
+        if ($targetEnvironment) {
             try {
-                $sshUrl = $this->getSelectedEnvironment()->getSshUrl();
+                $sshUrl = $targetEnvironment->getSshUrl();
                 /** @var \Platformsh\Cli\Service\Relationships $relationships */
                 $relationships = $this->getService('relationships');
                 $relationships->clearCaches($sshUrl);

--- a/src/Model/Host/RemoteHost.php
+++ b/src/Model/Host/RemoteHost.php
@@ -87,7 +87,7 @@ class RemoteHost implements HostInterface
      */
     public function getCacheKey()
     {
-        return $this->sshUrl;
+        return $this->sshUrl . '--' . $this->environment->head_commit;
     }
 
     public function lastChanged()

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -534,7 +534,7 @@ class Git
      *
      * @return array
      */
-    private function setupSshEnv()
+    public function setupSshEnv()
     {
         if (isset($this->ssh) && !isset($this->sshCommand)) {
             $this->sshCommand = $this->ssh->getSshCommand($this->extraSshOptions);

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -304,14 +304,6 @@ class Relationships implements InputConfiguringInterface
     }
 
     /**
-     * @param string $sshUrl
-     */
-    public function clearCaches($sshUrl)
-    {
-        $this->envVarService->clearCaches($sshUrl);
-    }
-
-    /**
      * @return bool
      */
     public function hasLocalEnvVar()

--- a/src/Service/RemoteEnvVars.php
+++ b/src/Service/RemoteEnvVars.php
@@ -108,18 +108,4 @@ class RemoteEnvVars
 
         return json_decode(base64_decode($value), true) ?: [];
     }
-
-    /**
-     * Clear caches for remote environment variables.
-     *
-     * @param string $sshUrl    The SSH URL to the application.
-     * @param array  $variables A list of unprefixed variables.
-     */
-    public function clearCaches($sshUrl, array $variables = ['APPLICATION', 'RELATIONSHIPS', 'ROUTES'])
-    {
-        $prefix = $this->config->get('service.env_prefix');
-        foreach ($variables as $variable) {
-            $this->cache->delete('env-' . $sshUrl . '-' . $prefix . $variable);
-        }
-    }
 }

--- a/src/Service/Shell.php
+++ b/src/Service/Shell.php
@@ -74,7 +74,7 @@ class Shell
     }
 
     /**
-     * Execute a command.
+     * Executes a command.
      *
      * @param string|array $args
      * @param string|null  $dir
@@ -92,6 +92,44 @@ class Shell
      *   string if it succeeds with output.
      */
     public function execute($args, $dir = null, $mustRun = false, $quiet = true, array $env = [], $timeout = 3600, $input = null)
+    {
+        $process = $this->setupProcess($args, $dir, $env, $timeout, $input);
+        $result = $this->runProcess($process, $mustRun, $quiet);
+
+        return is_int($result) ? $result === 0 : $result;
+    }
+
+    /**
+     * Executes a command and returns the process object.
+     *
+     * @param string|array $args
+     * @param string|null $dir
+     * @param bool $mustRun
+     * @param bool $quiet
+     * @param array $env
+     * @param int|null $timeout
+     * @param string|null $input
+     *
+     * @return Process
+     */
+    public function executeCaptureProcess($args, $dir = null, $mustRun = false, $quiet = true, array $env = [], $timeout = 3600, $input = null)
+    {
+        $process = $this->setupProcess($args, $dir, $env, $timeout, $input);
+        $this->runProcess($process, $mustRun, $quiet);
+        return $process;
+    }
+
+    /**
+     * Sets up a Process and reports to the user that the command is being run.
+     *
+     * @param $args
+     * @param $dir
+     * @param array $env
+     * @param $timeout
+     * @param $input
+     * @return Process
+     */
+    private function setupProcess($args, $dir = null, array $env = [], $timeout = 3600, $input = null)
     {
         $process = new Process($args, null, null, $input, $timeout);
 
@@ -125,9 +163,7 @@ class Shell
             $this->showWorkingDirMessage($dir);
         }
 
-        $result = $this->runProcess($process, $mustRun, $quiet);
-
-        return is_int($result) ? $result === 0 : $result;
+        return $process;
     }
 
     /**


### PR DESCRIPTION
* Add a configuration option `detection.push_deploy_error_messages` which lists messages that indicate a deployment error, e.g. "Error building project" or "Environment redeployment failed".
* If one of these error messages is found in the `git push` stderr log, report it and return a non-zero (failure) exit code, `87`.
* Note this is only possible on the push that causes the initial error; a subsequent push without a new commit would result in "Everything up-to-date" and a zero (success) exit code.

![screenshot-platform-push-check](https://github.com/platformsh/legacy-cli/assets/1465106/34a12181-631b-424b-b8d5-b2f08d788cee)
