### PR TITLE
Loosely validate profile sizes in resources:set command

### DIFF
--- a/src/Command/Resources/ResourcesSetCommand.php
+++ b/src/Command/Resources/ResourcesSetCommand.php
@@ -381,16 +381,16 @@ class ResourcesSetCommand extends ResourcesCommandBase
     protected function validateInstanceCount($value, $serviceName, $service, $limit)
     {
         if ($service instanceof Service) {
-            return sprintf('The instance count of the service <error>%s</error> cannot be changed.', $serviceName);
+            throw new InvalidArgumentException(sprintf('The instance count of the service <error>%s</error> cannot be changed.', $serviceName));
         }
         $count = (int) $value;
         if ($count != $value || $value <= 0) {
-            return sprintf('Invalid instance count <error>%s</error>: it must be an integer greater than 0.', $value);
+            throw new InvalidArgumentException(sprintf('Invalid instance count <error>%s</error>: it must be an integer greater than 0.', $value));
         }
         if ($limit !== null && $count > $limit) {
-            return sprintf('The instance count <error>%d</error> exceeds the limit %d.', $count, $limit);
+            throw new InvalidArgumentException(sprintf('The instance count <error>%d</error> exceeds the limit %d.', $count, $limit));
         }
-        return intval($value);
+        return $count;
     }
 
     /**

--- a/src/Command/Resources/ResourcesSetCommand.php
+++ b/src/Command/Resources/ResourcesSetCommand.php
@@ -443,7 +443,7 @@ class ResourcesSetCommand extends ResourcesCommandBase
         $sizes = array_keys($deployment->container_profiles[$containerProfile]);
         foreach ($sizes as $size) {
             if ($value == $size) {
-                return $size;
+                return (string) $size;
             }
         }
         throw new InvalidArgumentException(sprintf('Size <error>%s</error> not found in container profile <comment>%s</comment>; the available sizes are: <comment>%s</comment>', $value, $containerProfile, implode('</comment>, <comment>', $sizes)));


### PR DESCRIPTION
Currently profile sizes must match exactly, with an exception of those prefixed by a dot ".5" being assumed as "0.5", etc.

This PR replaces this with PHP's loose comparison, which compares numeric strings like this as [floats](https://www.php.net/manual/en/language.types.float.php), meaning "4.0" matches "4" (and vice versa), ".5" still matches "0.5", and  "4.0000000000000001" also matches "4" (and an empty string would match "0", not that there is a size zero).

It has a side effect of making the code look a bit (I believe) simpler.

![image](https://github.com/platformsh/legacy-cli/assets/1465106/ce3965b6-927d-4cd2-a812-a25c85273077)
