### PR TITLE
Show simpler command names in help (usage + examples)

### DIFF
--- a/src/Command/ClearCacheCommand.php
+++ b/src/Command/ClearCacheCommand.php
@@ -13,7 +13,8 @@ class ClearCacheCommand extends CommandBase
     {
         $this
             ->setName('clear-cache')
-            ->setAliases(['clearcache', 'cc'])
+            ->setAliases(['cc'])
+            ->setHiddenAliases(['clearcache'])
             ->setDescription('Clear the CLI cache');
     }
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -74,7 +74,6 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     protected $chooseEnvText = 'Enter a number to choose an environment:';
     protected $enterEnvText = 'Enter an environment ID';
     protected $hiddenInList = false;
-    protected $preferredName = '';
     protected $stability = self::STABILITY_STABLE;
     protected $local = false;
     protected $canBeRunMultipleTimes = true;
@@ -1970,13 +1969,16 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     }
 
     /**
-     * Returns the shortest command name for use in help.
+     * Returns the preferred command name for use in help.
      *
      * @return string
      */
     public function getPreferredName()
     {
-        return $this->preferredName ? $this->preferredName : $this->getName();
+        if ($visibleAliases = $this->getVisibleAliases()) {
+            return reset($visibleAliases);
+        }
+        return $this->getName();
     }
 
     /**

--- a/src/Command/Environment/EnvironmentBranchCommand.php
+++ b/src/Command/Environment/EnvironmentBranchCommand.php
@@ -10,8 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EnvironmentBranchCommand extends CommandBase
 {
-    protected $preferredName = 'branch';
-
     protected function configure()
     {
         $this

--- a/src/Command/Environment/EnvironmentRelationshipsCommand.php
+++ b/src/Command/Environment/EnvironmentRelationshipsCommand.php
@@ -17,7 +17,7 @@ class EnvironmentRelationshipsCommand extends CommandBase
     {
         $this
             ->setName('environment:relationships')
-            ->setAliases(['relationships'])
+            ->setAliases(['relationships', 'rel'])
             ->setDescription('Show an environment\'s relationships')
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment')
             ->addOption('property', 'P', InputOption::VALUE_REQUIRED, 'The relationship property to view')

--- a/src/Command/Integration/Activity/IntegrationActivityListCommand.php
+++ b/src/Command/Integration/Activity/IntegrationActivityListCommand.php
@@ -25,7 +25,8 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
     {
         $this
             ->setName('integration:activity:list')
-            ->setAliases(['i:act'])
+            ->setAliases(['int:act'])
+            ->setHiddenAliases(['integration:activities', 'i:act'])
             ->addArgument('id', InputArgument::OPTIONAL, 'An integration ID. Leave blank to choose from a list.')
             ->addOption('type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Filter activities by type.'
@@ -42,7 +43,6 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result')
             ->addOption('incomplete', 'i', InputOption::VALUE_NONE, 'Only list incomplete activities')
             ->setDescription('Get a list of activities for an integration');
-        $this->setHiddenAliases(['integration:activities']);
         Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
         PropertyFormatter::configureInput($this->getDefinition());
         $this->addProjectOption();

--- a/src/Command/Metrics/AllMetricsCommand.php
+++ b/src/Command/Metrics/AllMetricsCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AllMetricsCommand extends MetricsCommandBase
 {
     protected $stability = self::STABILITY_BETA;
-    protected $preferredName = 'metrics';
 
     private $tableHeader = [
         'timestamp' => 'Timestamp',
@@ -52,7 +51,7 @@ class AllMetricsCommand extends MetricsCommandBase
     protected function configure()
     {
         $this->setName('metrics:all')
-            ->setAliases(['met', 'metrics'])
+            ->setAliases(['metrics', 'met'])
             ->setDescription('Show CPU, disk and memory metrics for an environment')
             ->addOption('bytes', 'B', InputOption::VALUE_NONE, 'Show sizes in bytes');
         $this->addExample('Show metrics for the last ' . (new Duration())->humanize(self::DEFAULT_RANGE));

--- a/src/Command/Organization/OrganizationSubscriptionListCommand.php
+++ b/src/Command/Organization/OrganizationSubscriptionListCommand.php
@@ -26,7 +26,8 @@ class OrganizationSubscriptionListCommand extends OrganizationCommandBase
     protected function configure()
     {
         $this->setName('organization:subscription:list')
-            ->setAliases(['organization:subscriptions'])
+            ->setAliases(['org:subs'])
+            ->setHiddenAliases(['organization:subscriptions'])
             ->setDescription('List subscriptions within an organization')
             ->addOption('page', null, InputOption::VALUE_REQUIRED, 'Page number. This enables pagination, despite configuration or --count.')
             ->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'The number of items to display per page. Use 0 to disable pagination. Ignored if --page is specified.')

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -27,7 +27,8 @@ class OrganizationUserListCommand extends OrganizationCommandBase
     {
         $this->setName('organization:user:list')
             ->setDescription('List organization users')
-            ->setAliases(['organization:users'])
+            ->setAliases(['org:users'])
+            ->setHiddenAliases(['organization:users'])
             ->addOrganizationOptions();
         PropertyFormatter::configureInput($this->getDefinition());
         Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);

--- a/src/Command/Self/SelfUpdateCommand.php
+++ b/src/Command/Self/SelfUpdateCommand.php
@@ -12,14 +12,14 @@ class SelfUpdateCommand extends CommandBase
     {
         $this
             ->setName('self:update')
-            ->setAliases(['self-update'])
+            ->setAliases(['update', 'up'])
+            ->setHiddenAliases(['self-update'])
             ->setDescription('Update the CLI to the latest version')
             ->addOption('no-major', null, InputOption::VALUE_NONE, 'Only update between minor or patch versions')
             ->addOption('unstable', null, InputOption::VALUE_NONE, 'Update to a new unstable version, if available')
             ->addOption('manifest', null, InputOption::VALUE_REQUIRED, 'Override the manifest file location')
             ->addOption('current-version', null, InputOption::VALUE_REQUIRED, 'Override the current version')
             ->addOption('timeout', null, InputOption::VALUE_REQUIRED, 'A timeout for the version check', 30);
-        $this->setHiddenAliases(['update']);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
If the command has (visible) aliases, pick the first alias as the "preferred name" of the command to display in the "Usage" and "Examples" section of the help. This also cleans up aliases of some commands for consistency.

![image](https://github.com/platformsh/legacy-cli/assets/1465106/57df1291-6de9-41c1-8fec-6dd542c55938)
