### PR TITLE
Simplify plans configuration for the project:create (create) command

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -149,13 +149,6 @@ service:
   # Optional URL to help about runtime operations.
   runtime_operations_help_url: null
 
-  # Used for the static list of plans in the 'create' command.
-  available_plans:
-    - development
-    - standard
-    - medium
-    - large
-
 # Configuration relating to API calls.
 # This can be overridden in the user config file.
 api:


### PR DESCRIPTION
Remove service.available_plans config, so there is no static list of plans. The plans list is fetched either from the organization setup options (the `/organizations/{id}/setup/options` API, if `api.organizations` is enabled), or from the `/plans` API.