### PR TITLE
Handle the inability to reactivate paused environments

### DIFF
--- a/src/Command/Environment/EnvironmentActivateCommand.php
+++ b/src/Command/Environment/EnvironmentActivateCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\Environment;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Util\OsUtil;
 use Platformsh\Client\Model\Environment;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -73,10 +74,31 @@ class EnvironmentActivateCommand extends CommandBase
                     $count--;
                     continue;
                 }
+                if ($environment->status === 'paused') {
+                    $output->writeln("The environment " . $this->api()->getEnvironmentLabel($environment, 'comment') . " is paused.");
+                    if (count($environments) === 1 && $input->isInteractive() && $questionHelper->confirm('Do you want to resume it?')) {
+                        return $this->runOtherCommand('environment:resume', [
+                            '--project' => $environment->project,
+                            '--environment' => $environment->id,
+                            '--wait' => $input->getOption('wait'),
+                            '--no-wait' => $input->getOption('no-wait'),
+                            '--yes' => true,
+                        ]);
+                    }
+                    $output->writeln(sprintf(
+                        'To resume the environment, run: <comment>%s environment:resume</comment>',
+                        $this->config()->get('application.executable')
+                    ));
+                    $count--;
+                    continue;
+                }
 
                 $output->writeln(
                     "Operation not available: The environment " . $this->api()->getEnvironmentLabel($environment, 'error') . " can't be activated."
                 );
+                if ($environment->is_dirty) {
+                    $output->writeln('An activity is currently in progress on the environment.');
+                }
                 continue;
             }
             $question = "Are you sure you want to activate the environment " . $this->api()->getEnvironmentLabel($environment) . "?";

--- a/src/Command/Environment/EnvironmentActivateCommand.php
+++ b/src/Command/Environment/EnvironmentActivateCommand.php
@@ -2,7 +2,6 @@
 namespace Platformsh\Cli\Command\Environment;
 
 use Platformsh\Cli\Command\CommandBase;
-use Platformsh\Cli\Util\OsUtil;
 use Platformsh\Client\Model\Environment;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -163,7 +163,7 @@ class EnvironmentPushCommand extends CommandBase
         if ($targetEnvironment) {
             $environmentLabel = $this->api()->getEnvironmentLabel($targetEnvironment, $mayBeProduction ? 'comment' : 'info');
             $this->stdErr->writeln(sprintf('Pushing <info>%s</info> to the environment %s of project %s', $source, $environmentLabel, $projectLabel));
-            if ($activateRequested && !$targetEnvironment->isActive()) {
+            if ($activateRequested && !$targetEnvironment->isActive() && $targetEnvironment->status !== 'paused') {
                 $this->stdErr->writeln('The environment will be activated.');
             }
         } else {
@@ -367,7 +367,7 @@ class EnvironmentPushCommand extends CommandBase
                     $targetEnvironment->update($updates)->getActivities()
                 );
             }
-            if (!$targetEnvironment->isActive()) {
+            if (!$targetEnvironment->isActive() && $targetEnvironment->status !== 'paused') {
                 $activities = array_merge($activities, $targetEnvironment->runOperation('activate')->getActivities());
             }
             $this->api()->clearEnvironmentsCache($project->id);


### PR DESCRIPTION
* Fixes "push --activate": when the environment is paused activation will not be attempted (it will automatically reactivate on deployment).
* Fixes the "environment:activate" error message when the environment is paused. When possible it will now prompt for resuming the environment.