### PR TITLE
Use MariaDB-specific command names in "db:" commands

### DIFF
--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -209,8 +209,9 @@ class DbDumpCommand extends CommandBase
                 break;
 
             default:
-                $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb-dump' : 'mysqldump';
-                $dumpCommand = $cmdName . ' --single-transaction '
+                $cmdName = $relationships->isMariaDB($database) ? 'mariadb-dump' : 'mysqldump';
+                $cmdInvocation = $relationships->mariaDbCommandWithFallback($cmdName);
+                $dumpCommand = $cmdInvocation . ' --single-transaction '
                     . $relationships->getDbCommandArgs($cmdName, $database, $schema);
                 if ($schemaOnly) {
                     $dumpCommand .= ' --no-data';

--- a/src/Command/Db/DbDumpCommand.php
+++ b/src/Command/Db/DbDumpCommand.php
@@ -209,8 +209,9 @@ class DbDumpCommand extends CommandBase
                 break;
 
             default:
-                $dumpCommand = 'mysqldump --single-transaction '
-                    . $relationships->getDbCommandArgs('mysqldump', $database, $schema);
+                $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb-dump' : 'mysqldump';
+                $dumpCommand = $cmdName . ' --single-transaction '
+                    . $relationships->getDbCommandArgs($cmdName, $database, $schema);
                 if ($schemaOnly) {
                     $dumpCommand .= ' --no-data';
                 }

--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -288,12 +288,13 @@ class DbSizeCommand extends CommandBase
     private function getMysqlCommand(array $database) {
         /** @var \Platformsh\Cli\Service\Relationships $relationships */
         $relationships = $this->getService('relationships');
-        $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb' : 'mysql';
+        $cmdName = $relationships->isMariaDB($database) ? 'mariadb' : 'mysql';
+        $cmdInvocation = $relationships->mariaDbCommandWithFallback($cmdName);
         $connectionParams = $relationships->getDbCommandArgs($cmdName, $database, '');
 
         return sprintf(
             '%s %s --no-auto-rehash --raw --skip-column-names',
-            $cmdName,
+            $cmdInvocation,
             $connectionParams
         );
     }

--- a/src/Command/Db/DbSizeCommand.php
+++ b/src/Command/Db/DbSizeCommand.php
@@ -288,10 +288,12 @@ class DbSizeCommand extends CommandBase
     private function getMysqlCommand(array $database) {
         /** @var \Platformsh\Cli\Service\Relationships $relationships */
         $relationships = $this->getService('relationships');
-        $connectionParams = $relationships->getDbCommandArgs('mysql', $database, '');
+        $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb' : 'mysql';
+        $connectionParams = $relationships->getDbCommandArgs($cmdName, $database, '');
 
         return sprintf(
-            'mysql %s --no-auto-rehash --raw --skip-column-names',
+            '%s %s --no-auto-rehash --raw --skip-column-names',
+            $cmdName,
             $connectionParams
         );
     }

--- a/src/Command/Db/DbSqlCommand.php
+++ b/src/Command/Db/DbSqlCommand.php
@@ -114,7 +114,8 @@ class DbSqlCommand extends CommandBase
                 break;
 
             default:
-                $sqlCommand = 'mysql --no-auto-rehash ' . $relationships->getDbCommandArgs('mysql', $database, $schema);
+                $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb' : 'mysql';
+                $sqlCommand = $cmdName . ' --no-auto-rehash ' . $relationships->getDbCommandArgs($cmdName, $database, $schema);
                 if ($query) {
                     if ($input->getOption('raw')) {
                         $sqlCommand .= ' --batch --raw';

--- a/src/Command/Db/DbSqlCommand.php
+++ b/src/Command/Db/DbSqlCommand.php
@@ -114,8 +114,9 @@ class DbSqlCommand extends CommandBase
                 break;
 
             default:
-                $cmdName = $relationships->supportsMariaDBCommands($database) ? 'mariadb' : 'mysql';
-                $sqlCommand = $cmdName . ' --no-auto-rehash ' . $relationships->getDbCommandArgs($cmdName, $database, $schema);
+                $cmdName = $relationships->isMariaDB($database) ? 'mariadb' : 'mysql';
+                $cmdInvocation = $relationships->mariaDbCommandWithFallback($cmdName);
+                $sqlCommand = $cmdInvocation . ' --no-auto-rehash ' . $relationships->getDbCommandArgs($cmdName, $database, $schema);
                 if ($query) {
                     if ($input->getOption('raw')) {
                         $sqlCommand .= ' --batch --raw';


### PR DESCRIPTION
MariaDB introduced the `mariadb` command as a symlink in [version 10.4.6](https://mariadb.com/kb/en/mariadb-1046-release-notes/) and then made it a separate binary in [10.5.2](https://mariadb.com/kb/en/mariadb-1052-release-notes/) with `mysql` being a symlink. Apparently and unfortunately the Debian mariadb-client package doesn't include the `mysql` symlink; the `mariadb-client-compat` package is needed on top.