### PR TITLE
Lock while generating certificates or refreshing tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.77.0 <2.0",
+        "platformsh/client": ">=0.78.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5e8abe4441dcef3a9e0d48d2a04a449",
+    "content-hash": "d206c7e6bdff7e0559a17c88eb0b6277",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -870,16 +870,16 @@
         },
         {
             "name": "pjcdawkins/guzzle-oauth2-plugin",
-            "version": "v2.3.1",
+            "version": "v2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pjcdawkins/guzzle-oauth2-plugin.git",
-                "reference": "f8139ff410824c68a6a341dcd88bf070e5908a9e"
+                "reference": "8409e94266896da3b5eb9e8231a267783466af66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pjcdawkins/guzzle-oauth2-plugin/zipball/f8139ff410824c68a6a341dcd88bf070e5908a9e",
-                "reference": "f8139ff410824c68a6a341dcd88bf070e5908a9e",
+                "url": "https://api.github.com/repos/pjcdawkins/guzzle-oauth2-plugin/zipball/8409e94266896da3b5eb9e8231a267783466af66",
+                "reference": "8409e94266896da3b5eb9e8231a267783466af66",
                 "shasum": ""
             },
             "require": {
@@ -912,22 +912,22 @@
             ],
             "description": "An OAuth2 plugin (subscriber) for Guzzle (forked from commerceguys/guzzle-oauth2-plugin)",
             "support": {
-                "source": "https://github.com/pjcdawkins/guzzle-oauth2-plugin/tree/master"
+                "source": "https://github.com/pjcdawkins/guzzle-oauth2-plugin/tree/v2.3.3"
             },
-            "time": "2020-04-15T07:44:29+00:00"
+            "time": "2023-05-22T15:13:44+00:00"
         },
         {
             "name": "platformsh/client",
-            "version": "0.77.0",
+            "version": "0.78.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "9d602227e8d1cc02f6290249865dd6df4b75f22f"
+                "reference": "33235114fb3fffecdf50bb4cfb2644688ea41506"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/9d602227e8d1cc02f6290249865dd6df4b75f22f",
-                "reference": "9d602227e8d1cc02f6290249865dd6df4b75f22f",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/33235114fb3fffecdf50bb4cfb2644688ea41506",
+                "reference": "33235114fb3fffecdf50bb4cfb2644688ea41506",
                 "shasum": ""
             },
             "require": {
@@ -936,7 +936,7 @@
                 "guzzlehttp/cache-subscriber": "~0.1",
                 "guzzlehttp/guzzle": "~5.3",
                 "php": ">=5.5.9",
-                "pjcdawkins/guzzle-oauth2-plugin": ">=2.3.1 <=3.0"
+                "pjcdawkins/guzzle-oauth2-plugin": ">=2.3.3 <=3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.5"
@@ -959,9 +959,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.77.0"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.78.0"
             },
-            "time": "2023-09-18T18:39:51+00:00"
+            "time": "2023-11-24T15:35:45+00:00"
         },
         {
             "name": "platformsh/console-form",
@@ -1111,23 +1111,23 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.9.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -1171,19 +1171,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-02-11T10:27:51+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "stecman/symfony-console-completion",
@@ -2510,8 +2506,22 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/master"
+                "source": "https://github.com/doctrine/instantiator/tree/1.0.5"
             },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
@@ -4108,5 +4118,5 @@
     "platform-overrides": {
         "php": "5.5.9"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -232,6 +232,10 @@ api:
   # Overridden by the {application.env_prefix}DISABLE_CACHE env var.
   disable_cache: false
 
+  # Disable local file-based locking for concurrency control.
+  # Overridden by the {application.env_prefix}DISABLE_LOCKS env var.
+  disable_locks: false
+
   # Disable SSL verification (not recommended).
   # Overridden by the {application.env_prefix}SKIP_SSL env var.
   skip_ssl: false

--- a/services.yaml
+++ b/services.yaml
@@ -26,7 +26,7 @@ services:
 
     api:
         class:     '\Platformsh\Cli\Service\Api'
-        arguments: ['@config', '@cache', '@output', '@token_config']
+        arguments: ['@config', '@cache', '@output', '@token_config', '@file_lock']
 
     app_finder:
       class:     '\Platformsh\Cli\Local\ApplicationFinder'
@@ -43,7 +43,7 @@ services:
 
     certifier:
       class:     '\Platformsh\Cli\SshCert\Certifier'
-      arguments: ['@api', '@config', '@shell', '@fs', '@output']
+      arguments: ['@api', '@config', '@shell', '@fs', '@output', '@file_lock']
 
     config:
         class:     '\Platformsh\Cli\Service\Config'
@@ -55,6 +55,10 @@ services:
     drush:
         class:     '\Platformsh\Cli\Service\Drush'
         arguments: ['@config', '@shell', '@local.project', '@api', '@app_finder']
+
+    file_lock:
+        class:     '\Platformsh\Cli\Service\FileLock'
+        arguments: ['@config']
 
     fs:
         class:     '\Platformsh\Cli\Service\Filesystem'

--- a/src/Command/Auth/AuthInfoCommand.php
+++ b/src/Command/Auth/AuthInfoCommand.php
@@ -52,7 +52,7 @@ class AuthInfoCommand extends CommandBase
 
         // Exit early if it's the user ID.
         if ($property === 'id' && $this->api()->authApiEnabled()) {
-            $userId = $this->api()->getMyUserId();
+            $userId = $this->api()->getMyUserId($input->getOption('refresh'));
             if ($userId === false) {
                 $this->stdErr->writeln('The current session is not associated with a user ID');
                 return 1;
@@ -61,7 +61,7 @@ class AuthInfoCommand extends CommandBase
             return 0;
         }
 
-        $info = $this->api()->getMyAccount();
+        $info = $this->api()->getMyAccount($input->getOption('refresh'));
 
         $propertiesToDisplay = ['id', 'first_name', 'last_name', 'username', 'email', 'phone_number_verified'];
         $info = array_intersect_key($info, array_flip($propertiesToDisplay));

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -357,6 +357,7 @@ class Config
             'COPY_ON_WINDOWS' => 'local.copy_on_windows',
             'DEBUG' => 'api.debug',
             'DISABLE_CACHE' => 'api.disable_cache',
+            'DISABLE_LOCKS' => 'api.disable_locks',
             'DRUSH' => 'local.drush_executable',
             'SESSION_ID' => 'api.session_id',
             'SKIP_SSL' => 'api.skip_ssl',

--- a/src/Service/FileLock.php
+++ b/src/Service/FileLock.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Platformsh\Cli\Service;
+
+class FileLock
+{
+    private $config;
+    private $fs;
+
+    private $checkIntervalMs;
+    private $timeLimit;
+    private $disabled;
+
+    private $locks = [];
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+        $this->fs = new \Symfony\Component\Filesystem\Filesystem();
+        $this->checkIntervalMs = 500;
+        $this->timeLimit = 30;
+        $this->disabled = (bool) $this->config->getWithDefault('api.disable_locks', false);
+    }
+
+    /**
+     * Acquires a lock, or waits for one if it already exists.
+     *
+     * @param string $lockName
+     *   A unique name for the lock.
+     * @param callable|null $onWait
+     *   A function to run when waiting starts.
+     * @param callable|null $check
+     *   A function to run each time the interval has passed. If it returns a
+     *   non-null value, waiting will stop, and the value will be returned
+     *   from this method.
+     *
+     * @return mixed|null
+     */
+    public function acquireOrWait($lockName, callable $onWait = null, callable $check = null)
+    {
+        if ($this->disabled) {
+            return null;
+        }
+        $runOnWait = false;
+        $filename = $this->filename($lockName);
+        $start = \time();
+        while (\time() - $start < $this->timeLimit) {
+            if (!\file_exists($filename)) {
+                break;
+            }
+            $content = \file_get_contents($filename);
+            if ($content === false || $content === '') {
+                break;
+            }
+            $lockedAt = \intval($content);
+            if ($lockedAt === 0 || \time() >= $lockedAt + $this->timeLimit) {
+                break;
+            }
+            if ($onWait !== null && !$runOnWait) {
+                $onWait();
+                $runOnWait = true;
+            }
+            \usleep($this->checkIntervalMs * 1000);
+            if ($check !== null) {
+                $result = $check();
+                if ($result !== null) {
+                    $this->release($lockName);
+                    return $result;
+                }
+            }
+        }
+        $this->fs->dumpFile($filename, (string) \time());
+        $this->locks[$lockName] = $lockName;
+        return null;
+    }
+
+    /**
+     * Releases a lock that was created by acquire().
+     *
+     * @param string $lockName
+     */
+    public function release($lockName)
+    {
+        if (!$this->disabled && isset($this->locks[$lockName])) {
+            $this->fs->dumpFile($this->filename($lockName), '');
+            unset($this->locks[$lockName]);
+        }
+    }
+
+    /**
+     * Destructor. Release locks that still exist on exit.
+     */
+    public function __destruct()
+    {
+        foreach ($this->locks as $lockName) {
+            $this->release($lockName);
+        }
+    }
+
+    /**
+     * @param string $lockName
+     * @return string
+     */
+    private function filename($lockName)
+    {
+        return $this->config->getWritableUserDir()
+            . DIRECTORY_SEPARATOR . 'locks'
+            . DIRECTORY_SEPARATOR
+            . preg_replace('/[^\w_-]+/', '-', $lockName)
+            . '.lock';
+    }
+}


### PR DESCRIPTION
This guards against most of the race condition bugs that occur while running
multiple instances of the CLI in parallel. It doesn't fix all of them.