### PR TITLE
Fix: always try to pick a default environment for the interactive choice

### DIFF
--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -243,7 +243,8 @@ class CompletionCommand extends ParentCompletionCommand
                 }
             }
         } elseif ($project = $this->getProject()) {
-            if ($environment = $this->api->getDefaultEnvironment($project, false, false)) {
+            $environments = $this->api->getEnvironments($project, false);
+            if ($environments && ($environment = $this->api->getDefaultEnvironment($environments, $project))) {
                 $apps = array_keys($environment->getSshUrls());
             }
         }

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -478,7 +478,7 @@ class EnvironmentPushCommand extends CommandBase
         if ($this->hasSelectedEnvironment()) {
             $defaultId = $this->getSelectedEnvironment()->id;
         } else {
-            $default = $this->api()->getDefaultEnvironment($project);
+            $default = $this->api()->getDefaultEnvironment($environments, $project);
             $defaultId = $default ? $default->id : null;
         }
         if (array_keys($environments) === [$defaultId]) {

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1341,23 +1341,25 @@ class Api
      * This may be the one set as the project's default_branch, or another
      * environment, e.g. if the user only has access to 1 environment.
      *
-     * @param Project   $project
+     * @param Environment[] $envs
+     * @param Project $project
      * @param bool $onlyDefaultBranch Only use the default_branch.
-     * @param bool|null $refresh
      *
      * @return Environment|null
      */
-    public function getDefaultEnvironment(Project $project, $onlyDefaultBranch = false, $refresh = null)
+    public function getDefaultEnvironment(array $envs, Project $project, $onlyDefaultBranch = false)
     {
         if ($project->default_branch === '') {
             throw new \RuntimeException('Default branch not set');
         }
-        if ($env = $this->getEnvironment($project->default_branch, $project, $refresh)) {
-            return $env;
-        } elseif ($onlyDefaultBranch) {
+        foreach ($envs as $env) {
+            if ($env->id === $project->default_branch) {
+                return $env;
+            }
+        }
+        if ($onlyDefaultBranch) {
             return null;
         }
-        $envs = $this->getEnvironments($project, $refresh);
 
         // If there is only one environment, use that.
         if (count($envs) <= 1) {
@@ -1378,11 +1380,6 @@ class Api
         });
         if (\count($main) === 1) {
             return \reset($main);
-        }
-
-        // Select the environment matching the default branch.
-        if (isset($envs[$project->default_branch])) {
-            return $envs[$project->default_branch];
         }
 
         return null;


### PR DESCRIPTION
Fixes a regression introduced in legacy-cli v4.11.0 (#1342), in which the default environment is not picked for the `ssh` command and others (any commands where the list of environment choices is filtered in some way).