### PR TITLE
Allow auto drush aliases to be turned off via a feature flag

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -87,6 +87,9 @@ application:
   installer_url: null
   manifest_url: null
 
+  # Enable auto-creating Drush aliases for Drupal environments.
+  drush_aliases: true
+
 # Configuration for working with projects locally.
 local:
   local_dir: null         # dynamically defaults to {service.project_config_dir}

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -236,9 +236,11 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             $this->api
                 ->dispatcher
                 ->addListener('login_required', [$this, 'login']);
-            $this->api
-                ->dispatcher
-                ->addListener('environments_changed', [$this, 'updateDrushAliases']);
+            if ($this->config()->get('application.drush_aliases')) {
+                $this->api
+                    ->dispatcher
+                    ->addListener('environments_changed', [$this, 'updateDrushAliases']);
+            }
             $this->apiHasListeners = true;
         }
 

--- a/src/Command/Local/LocalDrushAliasesCommand.php
+++ b/src/Command/Local/LocalDrushAliasesCommand.php
@@ -35,7 +35,13 @@ class LocalDrushAliasesCommand extends CommandBase
             return true;
         }
 
-        // Hide this command in the list if the project is not Drupal.
+        // Only show this command if drush_aliases are enabled.
+        if (!$this->config()->get('application.drush_aliases')) {
+            return true;
+        }
+
+        // Hide the command in the list while in a project directory, if the
+        // project is not Drupal.
         // Avoid checking if running in the home directory.
         $projectRoot = $this->getProjectRoot();
         if ($projectRoot && $this->config()->getHomeDirectory() !== getcwd() && !Drupal::isDrupal($projectRoot)) {


### PR DESCRIPTION
Allows automatic Drush alias functionality to be turned off with

```sh
export PLATFORMSH_CLI_APPLICATION_DRUSH_ALIASES=0
```

or

```sh
echo 'application: {drush_aliases: false}' >> ~/.platformsh/config.yaml
```