### PR TITLE
Skip fetching SSH keys if a cert is present

### DIFF
--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -135,7 +135,7 @@ class Ssh implements InputConfiguringInterface
             }
         }
 
-        if (empty($options['IdentitiesOnly']) && ($sessionIdentityFile = $this->sshKey->selectIdentity())) {
+        if (empty($options['IdentitiesOnly']) && empty($options['CertificateFile']) && ($sessionIdentityFile = $this->sshKey->selectIdentity())) {
             $options['IdentityFile'][] = $this->sshConfig->formatFilePath($sessionIdentityFile);
         }
 

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -75,11 +75,14 @@ class SshConfig {
             $lines[] = 'Host ' . implode(' ', $domainWildcards);
         }
 
-        $sessionIdentityFile = $this->sshKey->selectIdentity();
-        if ($sessionIdentityFile !== null) {
-            $lines[] = '# This SSH key was detected as corresponding to the session:';
-            $lines[] = sprintf('IdentityFile %s', $this->formatFilePath($sessionIdentityFile));
-            $lines[] = '';
+        $sessionIdentityFile = null;
+        if (!$certificate) {
+            $sessionIdentityFile = $this->sshKey->selectIdentity();
+            if ($sessionIdentityFile !== null) {
+                $lines[] = '# This SSH key was detected as corresponding to the session:';
+                $lines[] = sprintf('IdentityFile %s', $this->formatFilePath($sessionIdentityFile));
+                $lines[] = '';
+            }
         }
 
         $sessionSpecificFilename = $this->getSessionSshDir() . DIRECTORY_SEPARATOR . 'config';

--- a/src/Service/SshKey.php
+++ b/src/Service/SshKey.php
@@ -69,8 +69,13 @@ class SshKey {
             return null;
         }
 
-        $accountKeyFingerprints = $this->listAccountKeyFingerprints();
-        if (!$accountKeyFingerprints) {
+        try {
+            $accountKeyFingerprints = $this->listAccountKeyFingerprints();
+            if (!$accountKeyFingerprints) {
+                return null;
+            }
+        } catch (\Exception $e) {
+            $this->stdErr->writeln('Failed to list SSH keys: ' . $e->getMessage(), OutputInterface::VERBOSITY_VERBOSE);
             return null;
         }
 


### PR DESCRIPTION
Further reduces calls to the `/me` API (after #1365 )