### PR TITLE
Remove support for pre-"Auth" APIs

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -263,16 +263,10 @@ api:
   # though a recommendation will be displayed.
   write_user_ssh_config: null
 
-  # Whether the Auth API is enabled.
-  auth: true
-
-  # Whether the API supports project invitations (requires "auth").
-  invitations: false
-
-  # Whether the Organizations API is enabled (requires "auth").
+  # Whether the Organizations API is enabled.
   organizations: false
 
-  # Whether Centralized User Management is available (requires "auth" and "organizations").
+  # Whether Centralized User Management is available (requires "organizations").
   centralized_permissions: false
 
   # Whether the projects list should be fetched from the newer "extended-access" API instead of "/me".
@@ -283,7 +277,7 @@ api:
   # This can be null for no filtering, or a string or a list of strings.
   vendor_filter: null
 
-  # Whether the User Verification APIs (/me/verification and /users/ID/phonenumber) are enabled (requires "auth").
+  # Whether the User Verification APIs (/me/verification and /users/ID/phonenumber) are enabled.
   user_verification: false
 
   # Whether the Metrics API is enabled.

--- a/config.yaml
+++ b/config.yaml
@@ -51,7 +51,6 @@ api:
 
   ssh_domain_wildcards: ['*.platform.sh']
 
-  invitations: true
   organizations: true
   centralized_permissions: true
   user_verification: true

--- a/src/Command/ApiCurlCommand.php
+++ b/src/Command/ApiCurlCommand.php
@@ -9,14 +9,6 @@ class ApiCurlCommand extends CommandBase
 {
     protected $hiddenInList = true;
 
-    public function isEnabled() {
-        if (!$this->config()->has('api.base_url')) {
-            return false;
-        }
-
-        return parent::isEnabled();
-    }
-
     protected function configure()
     {
         $this->setName('api:curl')
@@ -27,7 +19,7 @@ class ApiCurlCommand extends CommandBase
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $url = $this->config()->get('api.base_url');
+        $url = $this->config()->getApiUrl();
 
         // Initialize the API service so that it gets CommandBase's event listeners
         // (allowing for auto login).

--- a/src/Command/Auth/AuthInfoCommand.php
+++ b/src/Command/Auth/AuthInfoCommand.php
@@ -51,7 +51,7 @@ class AuthInfoCommand extends CommandBase
         }
 
         // Exit early if it's the user ID.
-        if ($property === 'id' && $this->api()->authApiEnabled()) {
+        if ($property === 'id') {
             $userId = $this->api()->getMyUserId($input->getOption('refresh'));
             if ($userId === false) {
                 $this->stdErr->writeln('The current session is not associated with a user ID');

--- a/src/Command/Auth/AuthTokenCommand.php
+++ b/src/Command/Auth/AuthTokenCommand.php
@@ -29,12 +29,11 @@ class AuthTokenCommand extends CommandBase
             . ' Take care not to expose the token in a shared program or system, or to send the token to the wrong API domain.'
         );
         $executable = $this->config()->get('application.executable');
+        $apiUrl = $this->config()->getApiUrl();
         $examples = [
             'Print the payload for JWT-formatted tokens' => \sprintf('%s auth:token -W | cut -d. -f2 | base64 -d', $executable),
+            'Use the token in a curl command' => \sprintf('curl -H"$(%s auth:token -HW)" %s/users/me', $executable, rtrim($apiUrl, '/')),
         ];
-        if ($apiUrl = $this->config()->getWithDefault('api.base_url', '')) {
-            $examples['Use the token in a curl command'] = \sprintf('curl -H"$(%s auth:token -HW)" %s/users/me', $executable, rtrim($apiUrl, '/'));
-        }
         $help .= "\n\n<comment>Examples:</comment>";
         foreach ($examples as $description => $example) {
             $help .= "\n\n$description:\n  <info>$example</info>";

--- a/src/Command/Auth/VerifyPhoneNumberCommand.php
+++ b/src/Command/Auth/VerifyPhoneNumberCommand.php
@@ -21,10 +21,7 @@ class VerifyPhoneNumberCommand extends CommandBase
 
     public function isEnabled()
     {
-        $config = $this->config();
-        if (!$config->getWithDefault('api.user_verification', false)
-            || !$config->getWithDefault('api.auth', false)
-            || !$config->getWithDefault('api.base_url', '')) {
+        if (!$this->config()->getWithDefault('api.user_verification', false)) {
             return false;
         }
         return parent::isEnabled();

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -923,12 +923,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
     protected function addProjectOption()
     {
         $this->addOption('project', 'p', InputOption::VALUE_REQUIRED, 'The project ID or URL');
-
-        if ($this->config()->getWithDefault('api.base_url', '') !== '') {
-            $this->addHiddenOption('host', null, InputOption::VALUE_REQUIRED, 'Deprecated option, no longer used');
-        } else {
-            $this->addOption('host', null, InputOption::VALUE_REQUIRED, "The project's API hostname");
-        }
+        $this->addHiddenOption('host', null, InputOption::VALUE_REQUIRED, 'Deprecated option, no longer used');
 
         return $this;
     }
@@ -1560,9 +1555,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
         $environmentId = null;
 
         // Warn about using the deprecated --host option.
-        if ($this->config()->getWithDefault('api.base_url', '') !== '') {
-            $this->warnAboutDeprecatedOptions(['host']);
-        }
+        $this->warnAboutDeprecatedOptions(['host']);
 
         // Identify the project.
         if ($projectId !== null) {

--- a/src/Command/Organization/OrganizationCreateCommand.php
+++ b/src/Command/Organization/OrganizationCreateCommand.php
@@ -46,14 +46,11 @@ END_HELP;
                 'options' => $countryList,
                 'asChoice' => false,
                 'defaultCallback' => function () use ($countryList) {
-                    if ($this->api()->authApiEnabled()) {
-                        $userCountry = $this->api()->getUser()->country;
-                        if (isset($countryList[$userCountry])) {
-                            return $countryList[$userCountry];
-                        }
-                        return $userCountry ?: null;
+                    $userCountry = $this->api()->getUser()->country;
+                    if (isset($countryList[$userCountry])) {
+                        return $countryList[$userCountry];
                     }
-                    return null;
+                    return $userCountry ?: null;
                 },
                 'normalizer' => function ($value) { return $this->normalizeCountryCode($value); },
                 'validator' => function ($countryCode) use ($countryList) {

--- a/src/Command/Organization/OrganizationCurlCommand.php
+++ b/src/Command/Organization/OrganizationCurlCommand.php
@@ -22,7 +22,7 @@ class OrganizationCurlCommand extends OrganizationCommandBase
     {
         $organization = $this->validateOrganizationInput($input);
 
-        $apiUrl = Url::fromString($this->config()->get('api.base_url'));
+        $apiUrl = Url::fromString($this->config()->getApiUrl());
         $absoluteUrl = $apiUrl->combine($organization->getUri())->__toString();
 
         /** @var CurlCli $curl */

--- a/src/Command/User/UserAddCommand.php
+++ b/src/Command/User/UserAddCommand.php
@@ -30,9 +30,7 @@ class UserAddCommand extends CommandBase
 
         $this->addRoleOption();
 
-        if ($this->config()->getWithDefault('api.invitations', false)) {
-            $this->addOption('force-invite', null, InputOption::VALUE_NONE, 'Send an invitation, even if one has already been sent');
-        }
+        $this->addOption('force-invite', null, InputOption::VALUE_NONE, 'Send an invitation, even if one has already been sent');
 
         $this->addProjectOption();
         $this->addWaitOptions();
@@ -319,7 +317,7 @@ class UserAddCommand extends CommandBase
         $this->stdErr->writeln('');
 
         // If the user does not already exist on the project, then use the Invitations API.
-        if (!$existingProjectAccess && $this->config()->getWithDefault('api.invitations', false)) {
+        if (!$existingProjectAccess) {
             $this->stdErr->writeln('Inviting the user to the project...');
             $permissions = [];
             foreach ($desiredTypeRoles as $type => $role) {
@@ -343,14 +341,7 @@ class UserAddCommand extends CommandBase
         }
 
         // Make the desired changes at the project level.
-        if (!$existingProjectAccess) {
-            $this->stdErr->writeln("Adding the user to the project");
-            $result = $project->addUser($email, $desiredProjectRole);
-            $activities = $result->getActivities();
-            /** @var ProjectAccess $projectAccess */
-            $projectAccess = $result->getEntity();
-            $userId = $projectAccess->id;
-        } elseif ($existingProjectAccess->role !== $desiredProjectRole) {
+        if ($existingProjectAccess->role !== $desiredProjectRole) {
             $this->stdErr->writeln("Setting the user's project role to: $desiredProjectRole");
             $result = $existingProjectAccess->update(['role' => $desiredProjectRole]);
             $activities = $result->getActivities();

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -312,7 +312,6 @@ class Api
             return $this->onRefreshError($e);
         };
 
-        $connectorOptions['auth_api_enabled'] = true;
         $connectorOptions['centralized_permissions_enabled'] = $this->config->get('api.centralized_permissions');
 
         return $connectorOptions;

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -264,7 +264,7 @@ class Api
      */
     private function getConnectorOptions() {
         $connectorOptions = [];
-        $connectorOptions['api_url'] = $this->config->getWithDefault('api.base_url', '');
+        $connectorOptions['api_url'] = $this->config->getApiUrl();
         if ($this->config->has('api.accounts_api_url')) {
             $connectorOptions['accounts'] = $this->config->get('api.accounts_api_url');
         }
@@ -312,7 +312,7 @@ class Api
             return $this->onRefreshError($e);
         };
 
-        $connectorOptions['auth_api_enabled'] = $this->config->get('api.auth');
+        $connectorOptions['auth_api_enabled'] = true;
         $connectorOptions['centralized_permissions_enabled'] = $this->config->get('api.centralized_permissions');
 
         return $connectorOptions;
@@ -641,20 +641,14 @@ class Api
      * Return the user's project with the given ID.
      *
      * @param string      $id      The project ID.
-     * @param string|null $host    The project's hostname. @deprecated no longer used if an api.base_url is configured.
+     * @param string|null $host    @deprecated no longer used
      * @param bool|null   $refresh Whether to bypass the cache.
      *
      * @return Project|false
      */
     public function getProject($id, $host = null, $refresh = null)
     {
-        // Ignore the $host if an api.base_url is configured.
-        $apiUrl = $this->config->getWithDefault('api.base_url', '');
-        if ($apiUrl !== '') {
-            $host = null;
-        }
-
-        $cacheKey = sprintf('%s:project:%s:%s', $this->config->getSessionId(), $id, $host);
+        $cacheKey = sprintf('%s:project:%s', $this->config->getSessionId(), $id);
         $cached = $this->cache->fetch($cacheKey);
 
         if ($refresh || !$cached) {
@@ -679,10 +673,7 @@ class Api
             $project = new Project($cached, $baseUrl, $guzzleClient);
             $this->debug('Loaded project from cache: ' . $id);
         }
-        $apiUrl = $this->config->getWithDefault('api.base_url', '');
-        if ($apiUrl) {
-            $project->setApiUrl($apiUrl);
-        }
+        $project->setApiUrl($this->config->getApiUrl());
 
         return $project;
     }
@@ -839,34 +830,14 @@ class Api
      *     'last_name': string,
      *     'display_name': string,
      *     'phone_number_verified': bool,
-     *     'uuid'?: string
      * }
      */
     public function getMyAccount($reset = false)
     {
-        $info = ['id' => '', 'username' => '', 'email' => '', 'first_name' => '', 'last_name' => '', 'phone_number_verified' => false];
-        if ($this->authApiEnabled()) {
-            $user = $this->getUser(null, $reset);
-            $info = array_merge($info, $user->getProperties());
-            $info['display_name'] = trim($user->first_name . ' ' . $user->last_name);
-        } else {
-            $account = $this->getLegacyAccountInfo($reset);
-            $info = [
-                'id' => $account['id'],
-                'username' => $account['username'],
-                'email' => $account['mail'],
-                'display_name' => $account['display_name'],
-            ];
-            if (isset($account['display_name'])) {
-                $parts = \explode(' ', $account['display_name'], 2);
-                if (count($parts) === 2) {
-                    list($info['first_name'], $info['last_name']) = $parts;
-                } else {
-                    $info['last_name'] = $account['display_name'];
-                }
-            }
-        }
-        return $info;
+        $user = $this->getUser(null, $reset);
+        return $user->getProperties() + [
+            'display_name' => trim($user->first_name . ' ' . $user->last_name),
+        ];
     }
 
     /**
@@ -901,16 +872,6 @@ class Api
     }
 
     /**
-     * Determines if the Auth API can be used, e.g. the getUser() method.
-     *
-     * @return bool
-     */
-    public function authApiEnabled()
-    {
-        return $this->config->getWithDefault('api.auth', false) && $this->config->getWithDefault('api.base_url', '');
-    }
-
-    /**
      * Get the logged-in user's SSH keys.
      *
      * @param bool $reset
@@ -921,7 +882,7 @@ class Api
     {
         $data = $this->getLegacyAccountInfo($reset);
 
-        return SshKey::wrapCollection($data['ssh_keys'], rtrim($this->config->get('api.base_url'), '/') . '/', $this->getHttpClient());
+        return SshKey::wrapCollection($data['ssh_keys'], rtrim($this->config->getApiUrl(), '/') . '/', $this->getHttpClient());
     }
 
     /**
@@ -963,8 +924,6 @@ class Api
      *
      * This is from the /users API which deals with basic authentication-related data.
      *
-     * @see Api::authApiEnabled()
-     *
      * @param string|null $id
      *   The user ID. Defaults to the current user.
      * @param bool $reset
@@ -973,9 +932,6 @@ class Api
      */
     public function getUser($id = null, $reset = false)
     {
-        if (!$this->config->getWithDefault('api.auth', false)) {
-            throw new \BadMethodCallException('api.auth must be enabled for this method');
-        }
         if ($id) {
             $cacheKey = 'user:' . $id;
         } else {

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -679,4 +679,14 @@ class Config
             }
         }
     }
+
+    /**
+     * Returns the base API URL.
+     *
+     * @return string
+     */
+    public function getApiUrl()
+    {
+        return (string) $this->get('api.base_url');
+    }
 }

--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -216,17 +216,7 @@ class SshDiagnostics
 
             $this->stdErr->writeln('The SSH connection failed because access requires MFA (multi-factor authentication).');
 
-            if (!$this->api->authApiEnabled()) {
-                if ($this->config->has('api.mfa_setup_url')) {
-                    $this->stdErr->writeln(\sprintf(
-                        'Ensure that MFA is enabled on your account. Set it up at: <comment>%s</comment>',
-                        $this->config->get('api.mfa_setup_url')
-                    ));
-                    $this->stdErr->writeln(\sprintf('Then log in again with: <comment>%s login -f</comment>', $executable));
-                } else {
-                    $this->stdErr->writeln(\sprintf('Log in again with: <comment>%s login -f</comment>', $executable));
-                }
-            } elseif ($this->api->getUser()->mfa_enabled) {
+            if ($this->api->getUser()->mfa_enabled) {
                 $this->stdErr->writeln('MFA is currently enabled on your account, but reverification is required.');
                 $this->stdErr->writeln(\sprintf('Log in again with: <comment>%s login -f</comment>', $executable));
             } else {


### PR DESCRIPTION
* Requires the config key `api.base_url` to be set everywhere
* Removes the config keys `api.auth` and `api.invitations`; assumes these APIs are enabled everywhere
* Removes now irrelevant backwards compatibility code

Related to https://github.com/platformsh/platformsh-client-php/pull/87