### PR TITLE
Stop setting "RequestTTY force" for SSH

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -278,10 +278,17 @@ ssh:
   host_keys_file: resources/ssh/host-keys
 
   # A list of SSH host keys to install for the user.
-  # They should be set as a string (one per line).
+  # They can be set as an array or a string (one per line).
   # If "host_keys_file" and "host_keys" are both empty or omitted, no extra
   # files will be written. If both are specified, both will be used.
-  host_keys: ''
+  host_keys: []
+
+  # A list of SSH configuration options.
+  # These will be passed to the SSH client appended to the CLI's other options.
+  # Options are an array of strings, each being a keyword and value separated
+  # by an equals sign or whitespace, e.g. "RequestTTY force". Alternatively
+  # they can be a single string (one per line).
+  options: []
 
   # If an SSH certificate is available, configure SSH to ignore other keys.
   cert_only: false

--- a/services.yaml
+++ b/services.yaml
@@ -134,7 +134,7 @@ services:
 
     ssh:
         class:     '\Platformsh\Cli\Service\Ssh'
-        arguments: ['@input', '@output', '@certifier', '@ssh_config', '@ssh_key']
+        arguments: ['@input', '@output', '@config', '@certifier', '@ssh_config', '@ssh_key']
 
     ssh_config:
         class:     '\Platformsh\Cli\Service\SshConfig'

--- a/src/Command/Db/DbSqlCommand.php
+++ b/src/Command/Db/DbSqlCommand.php
@@ -124,6 +124,7 @@ class DbSqlCommand extends CommandBase
                 break;
         }
 
+        // Enable tabular output when the input is a terminal.
         if ($host instanceof RemoteHost && $this->isTerminal(STDIN)) {
             $host->setExtraSshArgs(['-t']);
         }

--- a/src/Command/Environment/EnvironmentPushCommand.php
+++ b/src/Command/Environment/EnvironmentPushCommand.php
@@ -269,7 +269,7 @@ class EnvironmentPushCommand extends CommandBase
         $extraSshOptions = [];
         $env = [];
         if (!$this->shouldWait($input)) {
-            $extraSshOptions['SendEnv'] = 'PLATFORMSH_PUSH_NO_WAIT';
+            $extraSshOptions[] = 'SendEnv PLATFORMSH_PUSH_NO_WAIT';
             $env['PLATFORMSH_PUSH_NO_WAIT'] = '1';
         }
         $git->setExtraSshOptions($extraSshOptions);

--- a/src/Command/Environment/EnvironmentSshCommand.php
+++ b/src/Command/Environment/EnvironmentSshCommand.php
@@ -74,18 +74,9 @@ class EnvironmentSshCommand extends CommandBase
             throw new InvalidArgumentException('The cmd argument is required when running via "multi"');
         }
 
-        $sshOptions = [];
-        foreach ($input->getOption('option') as $option) {
-            $parts = explode(' ', $option, 2);
-            if (count($parts) < 2) {
-                throw new InvalidArgumentException('The option name and value must be separated by a space');
-            }
-            $sshOptions[$parts[0]] = $parts[1];
-        }
-
         /** @var \Platformsh\Cli\Service\Ssh $ssh */
         $ssh = $this->getService('ssh');
-        $command = $ssh->getSshCommand($sshOptions, $sshUrl, $remoteCommand);
+        $command = $ssh->getSshCommand($input->getOption('option'), $sshUrl, $remoteCommand);
 
         /** @var \Platformsh\Cli\Service\Shell $shell */
         $shell = $this->getService('shell');

--- a/src/Command/Environment/EnvironmentSshCommand.php
+++ b/src/Command/Environment/EnvironmentSshCommand.php
@@ -23,14 +23,16 @@ class EnvironmentSshCommand extends CommandBase
             ->addArgument('cmd', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'A command to run on the environment.')
             ->addOption('pipe', null, InputOption::VALUE_NONE, 'Output the SSH URL only.')
             ->addOption('all', null, InputOption::VALUE_NONE, 'Output all SSH URLs (for every app).')
+            ->addOption('option', 'o', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Pass an extra option to SSH')
             ->setDescription('SSH to the current environment');
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addRemoteContainerOptions();
         Ssh::configureInput($this->getDefinition());
         $this->addExample('Open a shell over SSH');
+        $this->addExample('Pass an extra option to SSH', "-o 'RequestTTY force'");
         $this->addExample('List files', 'ls');
-        $this->addExample("Monitor the app log (use '--' before options)", 'tail /var/log/app.log -- -n50 -f');
+        $this->addExample("Monitor the app log (use '--' before flags)", 'tail /var/log/app.log -- -n50 -f');
         $envPrefix = $this->config()->get('service.env_prefix');
         $this->addExample('Display relationships (use quotes for complex syntax)', "'echo \${$envPrefix}RELATIONSHIPS | base64 --decode'");
     }
@@ -72,12 +74,17 @@ class EnvironmentSshCommand extends CommandBase
             throw new InvalidArgumentException('The cmd argument is required when running via "multi"');
         }
 
+        $sshOptions = [];
+        foreach ($input->getOption('option') as $option) {
+            $parts = explode(' ', $option, 2);
+            if (count($parts) < 2) {
+                throw new InvalidArgumentException('The option name and value must be separated by a space');
+            }
+            $sshOptions[$parts[0]] = $parts[1];
+        }
+
         /** @var \Platformsh\Cli\Service\Ssh $ssh */
         $ssh = $this->getService('ssh');
-        $sshOptions = [];
-        if ($this->isTerminal(STDIN)) {
-            $sshOptions['RequestTTY'] = 'force';
-        }
         $command = $ssh->getSshCommand($sshOptions, $sshUrl, $remoteCommand);
 
         /** @var \Platformsh\Cli\Service\Shell $shell */

--- a/src/Command/Environment/EnvironmentXdebugCommand.php
+++ b/src/Command/Environment/EnvironmentXdebugCommand.php
@@ -122,8 +122,7 @@ class EnvironmentXdebugCommand extends CommandBase
         // Set up the tunnel
         $port = $input->getOption('port');
 
-        $sshOptions = [];
-        $sshOptions['ExitOnForwardFailure'] = 'yes';
+        $sshOptions = ['ExitOnForwardFailure yes'];
 
         $listenAddress = '127.0.0.1:' . $port;
         $commandTunnel = $ssh->getSshCommand($sshOptions) . ' -TNR ' . escapeshellarg(self::SOCKET_PATH . ':' . $listenAddress);

--- a/src/Command/Service/MongoDB/MongoShellCommand.php
+++ b/src/Command/Service/MongoDB/MongoShellCommand.php
@@ -54,6 +54,7 @@ class MongoShellCommand extends CommandBase
             $command .= ' --verbose';
         }
 
+        // Force TTY output when the input is a terminal.
         if ($this->isTerminal(STDIN) && $host instanceof RemoteHost) {
             $host->setExtraSshArgs(['-t']);
         }

--- a/src/Command/Service/RedisCliCommand.php
+++ b/src/Command/Service/RedisCliCommand.php
@@ -59,6 +59,7 @@ class RedisCliCommand extends CommandBase
             sprintf('Connecting to Redis service via relationship <info>%s</info> on <info>%s</info>', $service['_relationship_name'], $host->getLabel())
         );
 
+        // Force TTY output when the input is a terminal.
         if ($this->isTerminal(STDIN) && $host instanceof RemoteHost) {
             $host->setExtraSshArgs(['-t']);
         }

--- a/src/Command/SshCert/SshCertLoadCommand.php
+++ b/src/Command/SshCert/SshCertLoadCommand.php
@@ -62,12 +62,12 @@ class SshCertLoadCommand extends CommandBase
             $this->displayCertificate($sshCert);
         }
 
-        $sshConfig->configureHostKeys();
-        $hasSessionConfig = $sshConfig->configureSessionSsh();
-
         if ($input->getOption('refresh-only')) {
             return 0;
         }
+
+        $sshConfig->configureHostKeys();
+        $hasSessionConfig = $sshConfig->configureSessionSsh();
 
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -376,6 +376,8 @@ class Config
             'API_DOMAIN_SUFFIX' => 'detection.api_domain_suffix',
             'API_WRITE_USER_SSH_CONFIG' => 'ssh.write_user_config',
             'API_ADD_TO_SSH_AGENT' => 'ssh.add_to_agent',
+            'SSH_OPTIONS' => 'ssh.options',
+            'SSH_HOST_KEYS' => 'ssh.host_keys',
         ]);
 
         foreach ($overrideMap as $var => $key) {

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -519,7 +519,7 @@ class Git
     /**
      * Sets extra options to pass to the underlying SSH command.
      *
-     * @param array $options
+     * @param string[] $options
      */
     public function setExtraSshOptions(array $options)
     {

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -2,6 +2,7 @@
 
 namespace Platformsh\Cli\Service;
 
+use Platformsh\Cli\Console\HiddenInputOption;
 use Platformsh\Cli\SshCert\Certifier;
 use Platformsh\Cli\Util\OsUtil;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -35,7 +36,7 @@ class Ssh implements InputConfiguringInterface
     public static function configureInput(InputDefinition $definition)
     {
         $definition->addOption(
-            new InputOption('identity-file', 'i', InputOption::VALUE_REQUIRED, 'An SSH identity (private key) to use')
+            new HiddenInputOption('identity-file', 'i', InputOption::VALUE_REQUIRED, 'Deprecated: an SSH identity (private key) to use. The auto-generated certificate is recommended instead.')
         );
     }
 
@@ -99,11 +100,7 @@ class Ssh implements InputConfiguringInterface
             $options[] = 'LogLevel QUIET';
         }
 
-        if ($this->input->hasOption('identity-file') && $this->input->getOption('identity-file')) {
-            $file = $this->input->getOption('identity-file');
-            if (!file_exists($file)) {
-                throw new \InvalidArgumentException('Identity file not found: ' . $file);
-            }
+        if ($this->input->hasOption('identity-file') && ($file = $this->input->getOption('identity-file'))) {
             $options[] = 'IdentitiesOnly yes';
             $options[] = 'IdentityFile ' . $this->sshConfig->formatFilePath($file);
         } else {

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -100,9 +100,11 @@ class Ssh implements InputConfiguringInterface
             $options[] = 'LogLevel QUIET';
         }
 
+        $hasIdentity = false;
         if ($this->input->hasOption('identity-file') && ($file = $this->input->getOption('identity-file'))) {
-            $options[] = 'IdentitiesOnly yes';
             $options[] = 'IdentityFile ' . $this->sshConfig->formatFilePath($file);
+            $options[] = 'IdentitiesOnly yes';
+            $hasIdentity = true;
         } else {
             // Inject the SSH certificate.
             $sshCert = $this->certifier->getExistingCertificate();
@@ -127,11 +129,12 @@ class Ssh implements InputConfiguringInterface
                     if ($this->certifier->useCertificateOnly()) {
                         $options[] = 'IdentitiesOnly yes';
                     }
+                    $hasIdentity = true;
                 }
             }
         }
 
-        if (empty($options['IdentitiesOnly']) && ($sessionIdentityFile = $this->sshKey->selectIdentity())) {
+        if (!$hasIdentity && ($sessionIdentityFile = $this->sshKey->selectIdentity())) {
             $options[] = 'IdentityFile ' . $this->sshConfig->formatFilePath($sessionIdentityFile);
         }
 

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -14,14 +14,16 @@ class Ssh implements InputConfiguringInterface
 {
     protected $input;
     protected $output;
+    protected $config;
     protected $certifier;
     protected $sshConfig;
     protected $sshKey;
 
-    public function __construct(InputInterface $input, OutputInterface $output, Certifier $certifier, SshConfig $sshConfig, SshKey $sshKey)
+    public function __construct(InputInterface $input, OutputInterface $output, Config $config, Certifier $certifier, SshConfig $sshConfig, SshKey $sshKey)
     {
         $this->input = $input;
         $this->output = $output;
+        $this->config = $config;
         $this->sshKey = $sshKey;
         $this->certifier = $certifier;
         $this->sshConfig = $sshConfig;
@@ -139,6 +141,10 @@ class Ssh implements InputConfiguringInterface
         // Configure host keys and link them.
         if (($keysFile = $this->sshConfig->configureHostKeys()) !== null) {
             $options[] = 'UserKnownHostsFile ~/.ssh/known_hosts ~/.ssh/known_hosts2 ' . $this->sshConfig->formatFilePath($keysFile);
+        }
+
+        if ($configuredOptions = $this->config->get('ssh.options')) {
+            $options = array_merge($options, is_array($configuredOptions) ? $configuredOptions : explode("\n", $configuredOptions));
         }
 
         // Configure or validate the session SSH config.

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -111,8 +111,13 @@ class SshConfig {
             $lines[] = 'Host ' . implode(' ', $domainWildcards);
 
             $lines[] = '';
-            $lines[] = '# Include the certificate and its key.';
-            $lines[] = sprintf('CertificateFile %s', $this->formatFilePath($certificate->certificateFilename()));
+            if ($this->supportsCertificateFile()) {
+                $lines[] = '# Include the certificate and its key.';
+                $lines[] = sprintf('CertificateFile %s', $this->formatFilePath($certificate->certificateFilename()));
+            } else {
+                $lines[] = '# Include the certificate, via its key.';
+                $lines[] = '# The CertificateFile keyword could be used with OpenSSH 7.2 or later.';
+            }
             $lines[] = sprintf('IdentityFile %s', $this->formatFilePath($certificate->privateKeyFilename()));
             if ($onlyCertificate) {
                 $lines[] = 'IdentitiesOnly yes';

--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -111,7 +111,7 @@ class SshDiagnostics
     private function testConnection($uri, $timeout = 5)
     {
         $this->stdErr->writeln('Making test connection to diagnose SSH errors', OutputInterface::VERBOSITY_DEBUG);
-        $process = new Process($this->ssh->getSshCommand([], $uri, 'exit'));
+        $process = new Process($this->ssh->getSshCommand([], $uri, 'exit', false));
         $process->setTimeout($timeout);
         $process->run();
         $this->stdErr->writeln('Test connection complete', OutputInterface::VERBOSITY_DEBUG);


### PR DESCRIPTION
* Adds a configuration setting `ssh.options` allowing arbitrary SSH options to be appended.
* Adds an option `--option` (`-o`) in the `ssh` command for additional options.
* Passes on options to SSH without validating or changing them.
* Stops setting the "RequestTTY force" option for SSH in the `ssh` command.  
  This change is because this option is [potentially irritating](https://serverfault.com/a/593419) for scripting users and unnecessary for others.  
  The previous behavior can be restored with either:
  - `-o 'RequestTTY force'` or
  - `export PLATFORMSH_CLI_SSH_OPTIONS='RequestTTY force'`
* Allow SSH to continue even after failing to write configuration files.
* Do not (re)write config when running `ssh-cert:load --refresh-only`.