### PR TITLE
Add pagination to the org:users command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.79.4 <2.0",
+        "platformsh/client": ">=0.79.5 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.79.5 <2.0",
+        "platformsh/client": ">=0.79.6 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5d8f1e35609d876f765ec18097c33cc",
+    "content-hash": "6807b38135c5d185dfe20fc88a08365c",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -918,16 +918,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.79.5",
+            "version": "0.79.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "ec88fbd423c546511f76dfec1ffe8cdf03ab04c9"
+                "reference": "1e2a6d6cf2b74453e309e217d1a2523ab6a92726"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/ec88fbd423c546511f76dfec1ffe8cdf03ab04c9",
-                "reference": "ec88fbd423c546511f76dfec1ffe8cdf03ab04c9",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/1e2a6d6cf2b74453e309e217d1a2523ab6a92726",
+                "reference": "1e2a6d6cf2b74453e309e217d1a2523ab6a92726",
                 "shasum": ""
             },
             "require": {
@@ -959,9 +959,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.79.5"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.79.6"
             },
-            "time": "2023-12-29T16:41:38+00:00"
+            "time": "2024-01-03T17:34:50+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c32f8acd4bb982ae640730fb82fbb8c1",
+    "content-hash": "a5d8f1e35609d876f765ec18097c33cc",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -918,16 +918,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.79.4",
+            "version": "0.79.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "9c60ae83ec0555ce2e8ceab015e480c7c519da8a"
+                "reference": "ec88fbd423c546511f76dfec1ffe8cdf03ab04c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/9c60ae83ec0555ce2e8ceab015e480c7c519da8a",
-                "reference": "9c60ae83ec0555ce2e8ceab015e480c7c519da8a",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/ec88fbd423c546511f76dfec1ffe8cdf03ab04c9",
+                "reference": "ec88fbd423c546511f76dfec1ffe8cdf03ab04c9",
                 "shasum": ""
             },
             "require": {
@@ -959,9 +959,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.79.4"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.79.5"
             },
-            "time": "2023-12-29T09:54:13+00:00"
+            "time": "2023-12-29T16:41:38+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -2,15 +2,12 @@
 
 namespace Platformsh\Cli\Command\Organization\User;
 
-use GuzzleHttp\Url;
 use Platformsh\Cli\Command\Organization\OrganizationCommandBase;
 use Platformsh\Cli\Console\ProgressMessage;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
-use Platformsh\Cli\Util\OsUtil;
 use Platformsh\Client\Model\Organization\Member;
 use Platformsh\Client\Model\Resource;
-use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -36,7 +33,6 @@ class OrganizationUserListCommand extends OrganizationCommandBase
             ->setDescription('List organization users')
             ->addOption('count', null, InputOption::VALUE_REQUIRED, 'The number of items to display per page. Use 0 to disable pagination.')
             ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A property to sort by (created_at or updated_at). Prepend "-" to sort in descending order.', 'created_at')
-            ->addOption('page', null, InputOption::VALUE_REQUIRED, 'Show a specific page')
             ->setAliases(['org:users'])
             ->setHiddenAliases(['organization:users'])
             ->addOrganizationOptions();
@@ -72,10 +68,6 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         if ($count === '0') {
             $fetchAllPages = true;
             $options['query']['page[size]'] = 100;
-        }
-
-        if (!$fetchAllPages && ($pageId = $input->getOption('page'))) {
-            $options['query'] += $this->parsePageId($pageId);
         }
 
         $httpClient = $this->api()->getHttpClient();
@@ -139,12 +131,6 @@ class OrganizationUserListCommand extends OrganizationCommandBase
                 $this->stdErr->writeln('More users are available');
             }
             $this->stdErr->writeln('Show all users with: <info>--count 0</info>');
-            if (isset($result['next']) && ($pageId = $this->pageId($result['next'], 'after'))) {
-                $this->stdErr->writeln(sprintf('View the next page with: <info>--page %s</info>', OsUtil::escapeShellArg($pageId)));
-            }
-            if (isset($result['previous']) && ($pageId = $this->pageId($result['previous'], 'before'))) {
-                $this->stdErr->writeln(sprintf('View the previous page with: <info>--page %s</info>', OsUtil::escapeShellArg($pageId)));
-            }
         }
 
         if (!$table->formatIsMachineReadable()) {
@@ -156,40 +142,6 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         }
 
         return 0;
-    }
-
-    /**
-     * @param string $pageId
-     * @return array<string, string> A list of parameters to add to the URL.
-     */
-    private function parsePageId($pageId)
-    {
-        $types = ['a' => 'after', 'b' => 'before'];
-        if (!isset($types[$pageId[0]])) {
-            throw new InvalidArgumentException('Invalid page ID: ' . $pageId);
-        }
-        $key = 'page[' . $types[$pageId[0]] . ']';
-        $value = substr($pageId, 1);
-
-        return [$key => $value];
-    }
-
-    /**
-     * Generates an identifier for another page.
-     *
-     * @param string $url
-     *   The URL returned as the next or previous page.
-     * @param string $rel
-     *   The page type ('before' or 'after').
-     * @return string|null
-     */
-    private function pageId($url, $rel)
-    {
-        $page = Url::fromString($url)->getQuery()->get('page');
-        if (isset($page[$rel])) {
-            return $rel[0] . $page[$rel];
-        }
-        return null;
     }
 
     /**

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -166,11 +166,14 @@ class OrganizationUserListCommand extends OrganizationCommandBase
      */
     private function parsePageId($pageId)
     {
-        if (strpos($pageId, 'a') !== 0 && strpos($pageId, 'b') !== 0) {
+        $types = ['a' => 'after', 'b' => 'before'];
+        if (!isset($types[$pageId[0]])) {
             throw new InvalidArgumentException('Invalid page ID: ' . $pageId);
         }
+        $key = 'page[' . $types[$pageId[0]] . ']';
+        $value = substr($pageId, 1);
 
-        return [$pageId[0] === 'a' ? 'page[after]' : 'page[before]' => substr($pageId, 1)];
+        return [$key => $value];
     }
 
     /**

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -103,7 +103,8 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         foreach ($members as $member) {
             $userInfo = $member->getUserInfo();
             if (!$userInfo) {
-                throw new \RuntimeException('Member user info not found');
+                trigger_error(sprintf('User info not found for member: %s', $member->id), E_USER_WARNING);
+                continue;
             }
             $row = [
                 'id' => $member->id,

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -105,16 +105,12 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         $rows = [];
         foreach ($members as $member) {
             $userInfo = $member->getUserInfo();
-            if (!$userInfo) {
-                trigger_error(sprintf('User info not found for member: %s', $member->id), E_USER_WARNING);
-                continue;
-            }
             $row = [
                 'id' => $member->id,
-                'first_name' => $userInfo->first_name,
-                'last_name' => $userInfo->last_name,
-                'email' => $userInfo->email,
-                'username' => $userInfo->username,
+                'first_name' => $userInfo ? $userInfo->first_name : '',
+                'last_name' => $userInfo ? $userInfo->last_name : '',
+                'email' => $userInfo ? $userInfo->email : '',
+                'username' => $userInfo ? $userInfo->username : '',
                 'owner' => $formatter->format($member->owner, 'owner'),
                 'permissions' => $formatter->format($member->permissions, 'permissions'),
                 'updated_at' => $formatter->format($member->updated_at, 'updated_at'),

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -2,10 +2,17 @@
 
 namespace Platformsh\Cli\Command\Organization\User;
 
+use GuzzleHttp\Url;
 use Platformsh\Cli\Command\Organization\OrganizationCommandBase;
+use Platformsh\Cli\Console\ProgressMessage;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
+use Platformsh\Cli\Util\OsUtil;
+use Platformsh\Client\Model\Organization\Member;
+use Platformsh\Client\Model\Resource;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class OrganizationUserListCommand extends OrganizationCommandBase
@@ -27,6 +34,9 @@ class OrganizationUserListCommand extends OrganizationCommandBase
     {
         $this->setName('organization:user:list')
             ->setDescription('List organization users')
+            ->addOption('count', null, InputOption::VALUE_REQUIRED, 'The number of items to display per page. Use 0 to disable pagination.')
+            ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A property to sort by (created_at or updated_at). Prepend "-" to sort in descending order.', 'created_at')
+            ->addOption('page', null, InputOption::VALUE_REQUIRED, 'Show a specific page')
             ->setAliases(['org:users'])
             ->setHiddenAliases(['organization:users'])
             ->addOrganizationOptions();
@@ -43,7 +53,47 @@ class OrganizationUserListCommand extends OrganizationCommandBase
             return 1;
         }
 
-        $members = $organization->getMembers();
+        $options = [];
+
+        $count = $input->getOption('count');
+        $itemsPerPage = (int) $this->config()->getWithDefault('pagination.count', 20);
+        if ($count !== null && $count !== '0') {
+            if (!\is_numeric($count) || $count > 100) {
+                $this->stdErr->writeln('The --count must be a number between 1 and 100, or 0 to disable pagination.');
+                return 1;
+            }
+            $itemsPerPage = $count;
+        }
+
+        $options['query']['sort'] = $input->getOption('sort');
+
+        $options['query']['page[size]'] = $itemsPerPage;
+        $fetchAllPages = !$this->config()->getWithDefault('pagination.enabled', true);
+        if ($count === '0') {
+            $fetchAllPages = true;
+            $options['query']['page[size]'] = 100;
+        }
+
+        if (!$fetchAllPages && ($pageId = $input->getOption('page'))) {
+            $options['query'] += $this->parsePageId($pageId);
+        }
+
+        $httpClient = $this->api()->getHttpClient();
+        $url = $organization->getLink('members');
+        /** @var Member[] $members */
+        $members = [];
+
+        $progress = new ProgressMessage($output);
+        $progress->showIfOutputDecorated('Loading users...');
+        try {
+            do {
+                $result = Member::getPagedCollection($url, $httpClient, $options);
+                $members = array_merge($members, $result['items']);
+                $url = $result['next'];
+            } while (!empty($url) && $fetchAllPages);
+        } finally {
+            $progress->done();
+        }
 
         /** @var PropertyFormatter $formatter */
         $formatter = $this->getService('property_formatter');
@@ -77,13 +127,85 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         $table->render($rows, $this->tableHeader, $this->defaultColumns);
 
         if (!$table->formatIsMachineReadable()) {
+            $more = false;
+            if (!$fetchAllPages) {
+                $this->stdErr->writeln('');
+                if (($total = $this->total($members)) && $total > count($members)) {
+                    $this->stdErr->writeln(sprintf('More users are available (displaying <info>%d</info>, total <info>%d</info>)', count($members), $total));
+                    $more = true;
+                } elseif (isset($result['next']) || isset($result['previous'])) {
+                    $this->stdErr->writeln('More users are available');
+                    $more = true;
+                }
+            }
             $this->stdErr->writeln('');
-            $this->stdErr->writeln(\sprintf('To get full user details, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:get', '[email]')));
-            $this->stdErr->writeln(\sprintf('To add a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:add', '[email]')));
-            $this->stdErr->writeln(\sprintf('To update a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:update', '[email]')));
-            $this->stdErr->writeln(\sprintf('To remove a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:delete', '[email]')));
+            if ($more) {
+                $this->stdErr->writeln('Show all users with: <info>--count 0</info>');
+                if (isset($result['next']) && ($pageId = $this->pageId($result['next'], 'after'))) {
+                    $this->stdErr->writeln(sprintf('View the next page with: <info>--page %s</info>', OsUtil::escapeShellArg($pageId)));
+                }
+                if (isset($result['previous']) && ($pageId = $this->pageId($result['previous'], 'before'))) {
+                    $this->stdErr->writeln(sprintf('View the previous page with: <info>--page %s</info>', OsUtil::escapeShellArg($pageId)));
+                }
+                $this->stdErr->writeln('');
+                $this->stdErr->writeln(\sprintf('To get full user details, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:get', '[email]')));
+            } else {
+                $this->stdErr->writeln(\sprintf('To get full user details, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:get', '[email]')));
+                $this->stdErr->writeln(\sprintf('To add a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:add', '[email]')));
+                $this->stdErr->writeln(\sprintf('To update a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:update', '[email]')));
+                $this->stdErr->writeln(\sprintf('To remove a user, run: <info>%s</info>', $this->otherCommandExample($input, 'org:user:delete', '[email]')));
+            }
         }
 
         return 0;
+    }
+
+    /**
+     * @param string $pageId
+     * @return array<string, string> A list of parameters to add to the URL.
+     */
+    private function parsePageId($pageId)
+    {
+        if (strpos($pageId, 'a') !== 0 && strpos($pageId, 'b') !== 0) {
+            throw new InvalidArgumentException('Invalid page ID: ' . $pageId);
+        }
+
+        return [$pageId[0] === 'a' ? 'page[after]' : 'page[before]' => substr($pageId, 1)];
+    }
+
+    /**
+     * Generates an identifier for another page.
+     *
+     * @param string $url
+     *   The URL returned as the next or previous page.
+     * @param string $rel
+     *   The page type ('before' or 'after').
+     * @return string|null
+     */
+    private function pageId($url, $rel)
+    {
+        $page = Url::fromString($url)->getQuery()->get('page');
+        if (isset($page[$rel])) {
+            return $rel[0] . $page[$rel];
+        }
+        return null;
+    }
+
+    /**
+     * Finds the total count in a list of resources, if any.
+     *
+     * @param Resource[] $resources
+     * @return ?int
+     */
+    private function total($resources)
+    {
+        $res = end($resources);
+        if ($res && ($collection = $res->getParentCollection())) {
+            $collectionData = $collection->getData();
+            if (isset($collectionData['count'])) {
+                return $collectionData['count'];
+            }
+        }
+        return null;
     }
 }

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -86,10 +86,7 @@ class OrganizationUserListCommand extends OrganizationCommandBase
             do {
                 $result = Member::getCollectionWithParent($url, $httpClient, $options);
                 $members = array_merge($members, $result['items']);
-                $url = $result['collection']->hasNextPage()
-                    // TODO make a method for this
-                    ? $result['collection']->getData()['_links']['next']['href']
-                    : null;
+                $url = $result['collection']->getNextPageUrl();
             } while (!empty($url) && $fetchAllPages);
         } finally {
             $progress->done();
@@ -127,7 +124,7 @@ class OrganizationUserListCommand extends OrganizationCommandBase
 
         $table->render($rows, $this->tableHeader, $this->defaultColumns);
 
-        $total = (int) $result['collection']->getData()['count'];
+        $total = $result['collection']->getTotalCount();
         $moreAvailable = !$fetchAllPages && $total > count($members);
         if ($moreAvailable) {
             if (!$table->formatIsMachineReadable() || $this->stdErr->isDecorated()) {

--- a/src/Command/Organization/User/OrganizationUserListCommand.php
+++ b/src/Command/Organization/User/OrganizationUserListCommand.php
@@ -32,7 +32,8 @@ class OrganizationUserListCommand extends OrganizationCommandBase
         $this->setName('organization:user:list')
             ->setDescription('List organization users')
             ->addOption('count', null, InputOption::VALUE_REQUIRED, 'The number of items to display per page. Use 0 to disable pagination.')
-            ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A property to sort by (created_at or updated_at). Prepend "-" to sort in descending order.', 'created_at')
+            ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A property to sort by (created_at or updated_at)', 'created_at')
+            ->addOption('reverse', null, InputOption::VALUE_NONE, 'Reverse the sort order')
             ->setAliases(['org:users'])
             ->setHiddenAliases(['organization:users'])
             ->addOrganizationOptions();
@@ -61,7 +62,12 @@ class OrganizationUserListCommand extends OrganizationCommandBase
             $itemsPerPage = $count;
         }
 
-        $options['query']['sort'] = $input->getOption('sort');
+        if ($sort = $input->getOption('sort')) {
+            if ($input->getOption('reverse')) {
+                $sort = '-' . $sort;
+            }
+            $options['query']['sort'] = $sort;
+        }
 
         $options['query']['page[size]'] = $itemsPerPage;
         $fetchAllPages = !$this->config()->getWithDefault('pagination.enabled', true);


### PR DESCRIPTION
Adds `--count` and `--sort` options to the org:users command (`--count 0` to fetch all pages).

No specific `--page` option is provided as the API provides opaque cursor-based pagination which is powerful but could look confusing in this context.