### PR TITLE
Reduce SSH errors when connections and certificate refreshes are made in parallel

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -315,6 +315,16 @@ ssh:
   # Overridden by the {application.env_prefix}AUTO_LOAD_SSH_CERT env var
   auto_load_cert: true
 
+  # The lifetime of an automatically generated SSH key pair (in seconds).
+  #
+  # Set to 0 for the key pair never to expire or -1 for it to be regenerated
+  # every time the certificate is refreshed.
+  #
+  # Persisting the keys for longer can reduce errors from regenerating keys at
+  # the same time as an SSH connection. Conversely, regenerating the keys more
+  # often provides a weak security benefit.
+  cert_key_ttl: 86400
+
 # How the CLI detects and configures Git repositories as projects.
 detection:
   ## Required keys that must be defined elsewhere:

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -2152,7 +2152,7 @@ abstract class CommandBase extends Command implements MultiAwareInterface
             $this->stdErr->writeln('');
             $this->stdErr->writeln('Generating SSH certificate...');
             try {
-                $certifier->generateCertificate();
+                $certifier->generateCertificate(null);
                 $this->stdErr->writeln('A new SSH certificate has been generated.');
                 $this->stdErr->writeln('It will be automatically refreshed when necessary.');
             } catch (\Exception $e) {

--- a/src/Command/SshCert/SshCertInfoCommand.php
+++ b/src/Command/SshCert/SshCertInfoCommand.php
@@ -42,7 +42,7 @@ class SshCertInfoCommand extends CommandBase
                 return 1;
             }
             // Generate a new certificate.
-            $cert = $certifier->generateCertificate();
+            $cert = $certifier->generateCertificate($cert);
         }
 
         /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */

--- a/src/Command/SshCert/SshCertLoadCommand.php
+++ b/src/Command/SshCert/SshCertLoadCommand.php
@@ -15,7 +15,7 @@ class SshCertLoadCommand extends CommandBase
             ->setName('ssh-cert:load')
             ->addOption('refresh-only', null, InputOption::VALUE_NONE, 'Only refresh the certificate, if necessary (do not write SSH config)')
             ->addOption('new', null, InputOption::VALUE_NONE, 'Force the certificate to be refreshed')
-            ->addOption('new-key', null, InputOption::VALUE_NONE, '[Deprecated] Use --new instead')
+            ->addOption('new-key', null, InputOption::VALUE_NONE, 'Force a new key pair to be generated')
             ->setDescription('Generate an SSH certificate');
         $help = 'This command checks if a valid SSH certificate is present, and generates a new one if necessary.';
         if ($this->config()->getWithDefault('ssh.auto_load_cert', false)) {
@@ -58,7 +58,7 @@ class SshCertLoadCommand extends CommandBase
                 return 1;
             }
             $this->stdErr->writeln('Generating SSH certificate...');
-            $sshCert = $certifier->generateCertificate();
+            $sshCert = $certifier->generateCertificate($sshCert, $input->getOption('new-key'));
             $this->displayCertificate($sshCert);
         }
 

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -114,7 +114,7 @@ class Ssh implements InputConfiguringInterface
                 if ((!$sshCert || !$this->certifier->isValid($sshCert)) && $this->sshConfig->checkRequiredVersion()) {
                     $this->stdErr->writeln('Generating SSH certificate...', OutputInterface::VERBOSITY_VERBOSE);
                     try {
-                        $sshCert = $this->certifier->generateCertificate();
+                        $sshCert = $this->certifier->generateCertificate($sshCert);
                         $this->stdErr->writeln("A new SSH certificate has been generated.\n", OutputInterface::VERBOSITY_VERBOSE);
                     } catch (\Exception $e) {
                         $this->stdErr->writeln(sprintf("Failed to generate SSH certificate: <error>%s</error>\n", $e->getMessage()));

--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -200,7 +200,7 @@ class SshDiagnostics
 
         if ($this->connectionFailedDueToCertificateValidity($failedProcess)) {
             $this->stdErr->writeln('The SSH connection failed because the SSH certificate is no longer valid.');
-            $this->certifier->generateCertificate();
+            $this->certifier->generateCertificate($cert);
             $this->stdErr->writeln('A new SSH certificate has been generated. Please try again.');
             return;
         }


### PR DESCRIPTION
This PR alters certificate refreshing to make it no longer regenerate the
SSH key pair every time. It adds a config parameter `ssh.cert_key_ttl` (default
86400) for the lifetime in seconds of a key pair. Set to 0 for the key pair
never to expire or -1 for it to be regenerated every time the certificate is
refreshed. This can be overridden in the environment variable
`PLATFORMSH_CLI_SSH_CERT_KEY_TTL`.

This PR also ensures that new keys are written (or rather, renamed into
place) much closer to the time of saving the new certificate.

These changes will reduce the chance of a key pair being regenerated while it is
being read by another program (like SSH), for example if an SSH connection is
made at exactly the same time as another CLI process that is refreshing the
certificate. Three files are being saved (or now, renamed) - the certificate,
private key, and public key - which leaves the unfortunate possibility that SSH
may read the old version of one file and find it conflicts with another file.
This seems to happen more often than one might expect.