### PR TITLE
Add --resources-init option to five more commands

### DIFF
--- a/src/Command/Backup/BackupRestoreCommand.php
+++ b/src/Command/Backup/BackupRestoreCommand.php
@@ -20,6 +20,7 @@ class BackupRestoreCommand extends CommandBase
             ->addOption('target', null, InputOption::VALUE_REQUIRED, "The environment to restore to. Defaults to the backup's current environment")
             ->addOption('branch-from', null, InputOption::VALUE_REQUIRED, 'If the --target does not yet exist, this specifies the parent of the new environment')
             ->addOption('restore-code', null, InputOption::VALUE_NONE, 'Whether code should be restored as well as data');
+        $this->addResourcesInitOption('parent');
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addWaitOptions();
@@ -66,6 +67,12 @@ class BackupRestoreCommand extends CommandBase
         if ($branchFrom !== null && !$this->api()->getEnvironment($branchFrom, $project)) {
             $this->stdErr->writeln(sprintf('Environment not found (in --branch-from): <error>%s</error>', $branchFrom));
 
+            return 1;
+        }
+
+        // Validate the --resources-init option.
+        $resourcesInit = $this->validateResourcesInitInput($input, $project);
+        if ($resourcesInit === false) {
             return 1;
         }
 
@@ -117,6 +124,7 @@ class BackupRestoreCommand extends CommandBase
                 ->setEnvironmentName($targetName)
                 ->setBranchFrom($branchFrom)
                 ->setRestoreCode($input->getOption('restore-code'))
+                ->setResourcesInit($resourcesInit)
         );
 
         if ($this->shouldWait($input) && $result->countActivities()) {


### PR DESCRIPTION
If the api.sizing configuration flag is enabled, this adds the option to the following affected commands, in addition to the existing option on the `environment:push` (push) command. The option can only be used with projects that support the flexible resources API. It sets the strategy to be used for picking the size of new resources on the target environment: `parent`, `child`, `default`, `minimum`, or `manual`.

Affected commands:

* `backup:restore`
* `environment:activate`
* `environment:branch` (`branch`)
* `environment:merge` (`merge`)
* `environment:synchronize` (`sync`)

Part of #1384 

Test for Upsun with:

```
# Download Upsun config
curl -s https://raw.githubusercontent.com/platformsh/cli/main/internal/config/upsun-cli.yaml > /tmp/upsun-cli.yaml

# Download the build for this PR
curl -s https://pr-1400-x7xqtxy-mpaw4nkgdwaea.eu-2.platformsh.site/platform.phar > /tmp/platform-pr-1400.phar

# Create an alias
alias upsun='CLI_CONFIG_FILE=/tmp/upsun-cli.yaml php /tmp/platform-pr-1400.phar'

# Then run the above commands as "upsun ..."
```