### PR TITLE
Fix metrics for multi-instance grid hosting

### DIFF
--- a/src/Command/Metrics/MetricsCommandBase.php
+++ b/src/Command/Metrics/MetricsCommandBase.php
@@ -36,12 +36,12 @@ abstract class MetricsCommandBase extends CommandBase
     private $fields = [
         // Grid.
         'local' => [
-            'cpu_used' => "SUM((`cpu.user` + `cpu.kernel`) / `interval`, 'service')",
-            'cpu_percent' => "SUM(100 * (`cpu.user` + `cpu.kernel`) / (`interval` * `cpu.cores`), 'service')",
-            'cpu_limit' => "AVG(`cpu.cores`, 'service')",
+            'cpu_used' => "AVG(SUM((`cpu.user` + `cpu.kernel`) / `interval`, 'service', 'instance'), 'service')",
+            'cpu_percent' => "AVG(100 * SUM((`cpu.user` + `cpu.kernel`) / (`interval` * `cpu.cores`), 'service', 'instance'), 'service')",
+            'cpu_limit' => "SUM(`cpu.cores`, 'service')",
 
-            'mem_used' => "SUM(`memory.apps` + `memory.kernel` + `memory.buffers`, 'service')",
-            'mem_percent' => "SUM(100 * (`memory.apps` + `memory.kernel` + `memory.buffers`) / `memory.limit`, 'service')",
+            'mem_used' => "AVG(SUM(`memory.apps` + `memory.kernel` + `memory.buffers`, 'service', 'instance'), 'service')",
+            'mem_percent' => "AVG(100 * SUM((`memory.apps` + `memory.kernel` + `memory.buffers`) / `memory.limit`, 'service', 'instance'), 'service')",
             'mem_limit' => "AVG(`memory.limit`, 'service')",
 
             'disk_used' => "AVG(`disk.space.used`, 'mountpoint', 'service')",


### PR DESCRIPTION
Test for Upsun with:

```sh
# Download the normal Upsun CLI config
curl -s https://raw.githubusercontent.com/platformsh/cli/main/internal/config/upsun-cli.yaml > /tmp/upsun-cli.yaml

# Download the build for this PR
curl -s https://pr-1402-x5xx7sy-mpaw4nkgdwaea.eu-2.platformsh.site/platform.phar > /tmp/platform-pr-1402.phar

# Create an alias
alias upsun='CLI_CONFIG_FILE=/tmp/upsun-cli.yaml php /tmp/platform-pr-1402.phar'

# Run metrics commands
upsun cpu
upsun mem
```