### PR TITLE
Skip rerunning SSH cert check when SSHing from the CLI

### DIFF
--- a/src/Command/Environment/EnvironmentSshCommand.php
+++ b/src/Command/Environment/EnvironmentSshCommand.php
@@ -89,7 +89,7 @@ class EnvironmentSshCommand extends CommandBase
 
         $start = \time();
 
-        $exitCode = $shell->executeSimple($command);
+        $exitCode = $shell->executeSimple($command, null, $ssh->getEnv());
         if ($exitCode !== 0) {
             /** @var \Platformsh\Cli\Service\SshDiagnostics $diagnostics */
             $diagnostics = $this->getService('ssh_diagnostics');

--- a/src/Command/Environment/EnvironmentXdebugCommand.php
+++ b/src/Command/Environment/EnvironmentXdebugCommand.php
@@ -114,7 +114,7 @@ class EnvironmentXdebugCommand extends CommandBase
         $commandCleanup = $ssh->getSshCommand();
         $commandCleanup .= ' ' . escapeshellarg($sshUrl) . ' rm -f ' . escapeshellarg(self::SOCKET_PATH);
         $this->debug("Cleanup command: " . $commandCleanup);
-        $process = new Process($commandCleanup);
+        $process = new Process($commandCleanup, null, $ssh->getEnv());
         $process->run();
 
         $this->stdErr->writeln("Opening a local tunnel for Xdebug.");
@@ -128,7 +128,7 @@ class EnvironmentXdebugCommand extends CommandBase
         $commandTunnel = $ssh->getSshCommand($sshOptions) . ' -TNR ' . escapeshellarg(self::SOCKET_PATH . ':' . $listenAddress);
         $commandTunnel .= ' ' . escapeshellarg($sshUrl);
         $this->debug("Tunnel command: " . $commandTunnel);
-        $process = new Process($commandTunnel);
+        $process = new Process($commandTunnel, null, $ssh->getEnv());
         $process->setTimeout(null);
         $process->start();
 

--- a/src/Command/SshCert/SshCertLoadCommand.php
+++ b/src/Command/SshCert/SshCertLoadCommand.php
@@ -2,6 +2,7 @@
 namespace Platformsh\Cli\Command\SshCert;
 
 use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\Ssh;
 use Platformsh\Cli\SshCert\Certificate;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -41,6 +42,11 @@ class SshCertLoadCommand extends CommandBase
         $sshCert = $certifier->getExistingCertificate();
 
         $refresh = true;
+        if (getenv(Ssh::SSH_NO_REFRESH_ENV_VAR)) {
+            $this->stdErr->writeln(sprintf('Not refreshing SSH certificate (<comment>%s</comment> variable is set)', Ssh::SSH_NO_REFRESH_ENV_VAR));
+            $refresh = false;
+        }
+
         if ($sshCert
             && !$input->getOption('new')
             && !$input->getOption('new-key')

--- a/src/Model/Host/RemoteHost.php
+++ b/src/Model/Host/RemoteHost.php
@@ -49,7 +49,7 @@ class RemoteHost implements HostInterface
     public function runCommand($command, $mustRun = true, $quiet = true, $input = null)
     {
         try {
-            return $this->shell->execute($this->wrapCommandLine($command), null, $mustRun, $quiet, [], 3600, $input);
+            return $this->shell->execute($this->wrapCommandLine($command), null, $mustRun, $quiet, $this->sshService->getEnv(), 3600, $input);
         } catch (ProcessFailedException $e) {
             $this->sshDiagnostics->diagnoseFailure($this->sshUrl, $e->getProcess());
             throw new ProcessFailedException($e->getProcess(), false);
@@ -77,7 +77,7 @@ class RemoteHost implements HostInterface
     public function runCommandDirect($commandLine, $append = '')
     {
         $start = \time();
-        $exitCode = $this->shell->executeSimple($this->wrapCommandLine($commandLine) . $append);
+        $exitCode = $this->shell->executeSimple($this->wrapCommandLine($commandLine) . $append, null, $this->sshService->getEnv());
         $this->sshDiagnostics->diagnoseFailureWithTest($this->sshUrl, $start, $exitCode);
         return $exitCode;
     }

--- a/src/Service/Git.php
+++ b/src/Service/Git.php
@@ -547,9 +547,9 @@ class Git
             if (!isset($this->sshCommandFile) || \file_get_contents($this->sshCommandFile) !== $contents) {
                 $this->sshCommandFile = $this->writeSshFile($contents);
             }
-            return ['GIT_SSH' => $this->sshCommandFile];
+            return ['GIT_SSH' => $this->sshCommandFile] + $this->ssh->getEnv();
         }
-        return ['GIT_SSH_COMMAND' => $this->sshCommand];
+        return ['GIT_SSH_COMMAND' => $this->sshCommand] + $this->ssh->getEnv();
     }
 
     /**

--- a/src/Service/Rsync.php
+++ b/src/Service/Rsync.php
@@ -37,6 +37,7 @@ class Rsync
         $env = [];
         if ($this->ssh->getSshArgs() !== []) {
             $env['RSYNC_RSH'] = $this->ssh->getSshCommand();
+            $env += $this->ssh->getEnv();
         }
 
         return $env;

--- a/src/Service/Ssh.php
+++ b/src/Service/Ssh.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Ssh implements InputConfiguringInterface
 {
+    const SSH_NO_REFRESH_ENV_VAR = 'CLI_SSH_NO_REFRESH';
+
     protected $input;
     protected $output;
     protected $stdErr;
@@ -187,5 +189,16 @@ class Ssh implements InputConfiguringInterface
         }
 
         return $command;
+    }
+
+    /**
+     * Returns environment variables to set on SSH commands.
+     *
+     * @return array<string, string>
+     */
+    public function getEnv()
+    {
+        // Suppress refreshing the certificate while SSH is running through the CLI.
+        return [self::SSH_NO_REFRESH_ENV_VAR => '1'];
     }
 }

--- a/src/Service/SshDiagnostics.php
+++ b/src/Service/SshDiagnostics.php
@@ -111,7 +111,7 @@ class SshDiagnostics
     private function testConnection($uri, $timeout = 5)
     {
         $this->stdErr->writeln('Making test connection to diagnose SSH errors', OutputInterface::VERBOSITY_DEBUG);
-        $process = new Process($this->ssh->getSshCommand([], $uri, 'exit', false));
+        $process = new Process($this->ssh->getSshCommand([], $uri, 'exit', false), null, $this->ssh->getEnv());
         $process->setTimeout($timeout);
         $process->run();
         $this->stdErr->writeln('Test connection complete', OutputInterface::VERBOSITY_DEBUG);


### PR DESCRIPTION
Aims to improve performance (only on POSIX shells) when running the `ssh` and related commands, by modifying the generated SSH config so that it will not run the `ssh-cert:load` command unnecessarily, using an environment variable to determine when SSH is being run through the CLI. Seems to save 100-200ms in cursory test.