### PR TITLE
Move config service.header_prefix to detection.cluster_header and make it optional

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -115,7 +115,6 @@ service:
   # name: 'Example Service Name'
   # slug: 'example-service'
   # env_prefix: 'EXAMPLE_'
-  # header_prefix: 'X-Example'
   # project_config_dir: '.example'
 
   ## Config file for multiple applications.
@@ -329,6 +328,9 @@ detection:
   # git_remote_name: 'platform'
   # git_domain: 'example.com'
   # site_domains: ['example.com', 'example.site']
+
+  ## Site header which reports the cluster.
+  # cluster_header: 'X-Platform-Cluster'
 
   ## Domain of a Console instance.
   ##

--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,6 @@ service:
   name: 'Platform.sh'
   slug: 'platformsh'
   env_prefix: 'PLATFORM_'
-  header_prefix: 'X-Platform'
 
   project_config_dir: '.platform'
   app_config_file: '.platform.app.yaml'
@@ -62,6 +61,7 @@ detection:
   git_remote_name: 'platform'
   git_domain: 'platform.sh' # matches git.eu-5.platform.sh, etc.
   site_domains: ['platform.sh', 'platformsh.site', 'tst.site']
+  cluster_header: 'X-Platform-Cluster'
 
 migrate:
   prompt: true

--- a/src/Service/Config.php
+++ b/src/Service/Config.php
@@ -637,14 +637,17 @@ class Config
         }
 
         // Migrate renamed config keys.
-        if (isset($this->config['api']['add_to_ssh_agent'])) {
+        if (isset($this->config['api']['add_to_ssh_agent']) && !isset($this->config['ssh']['add_to_agent'])) {
             $this->config['ssh']['add_to_agent'] = $this->config['api']['add_to_ssh_agent'];
         }
-        if (isset($this->config['api']['auto_load_ssh_cert'])) {
+        if (isset($this->config['api']['auto_load_ssh_cert']) && !isset($this->config['ssh']['auto_load_cert'])) {
             $this->config['ssh']['auto_load_cert'] = $this->config['api']['auto_load_ssh_cert'];
         }
-        if (isset($this->config['api']['ssh_domain_wildcards'])) {
+        if (isset($this->config['api']['ssh_domain_wildcards']) && !isset($this->config['ssh']['domain_wildcards'])) {
             $this->config['ssh']['domain_wildcards'] = $this->config['api']['ssh_domain_wildcards'];
+        }
+        if (isset($this->config['service']['header_prefix']) && !isset($this->config['detection']['cluster_header'])) {
+            $this->config['detection']['cluster_header'] = $this->config['service']['header_prefix'] . '-Cluster';
         }
     }
 

--- a/src/Service/Identifier.php
+++ b/src/Service/Identifier.php
@@ -49,7 +49,7 @@ class Identifier
     public function identify($url)
     {
         $result = $this->parseProjectId($url);
-        if (empty($result['projectId']) && strpos($url, '.') !== false && $this->config->getWithDefault('detection.use_site_headers', true)) {
+        if (empty($result['projectId']) && strpos($url, '.') !== false && $this->config->has('detection.cluster_header')) {
             $result = $this->identifyFromHeaders($url);
         }
         if (empty($result['projectId'])) {
@@ -171,6 +171,9 @@ class Identifier
      */
     private function getClusterHeader($url)
     {
+        if (!$this->config->has('detection.cluster_header')) {
+            return false;
+        }
         $cacheKey = 'project-cluster:' . $url;
         $cluster = $this->cache ? $this->cache->fetch($cacheKey) : false;
         if ($cluster === false) {
@@ -193,7 +196,7 @@ class Identifier
                     return false;
                 }
             }
-            $cluster = $response->getHeaderAsArray($this->config->get('service.header_prefix') . '-cluster');
+            $cluster = $response->getHeaderAsArray($this->config->get('detection.cluster_header'));
             $canCache = !empty($cluster)
                 || ($response->getStatusCode() >= 200 && $response->getStatusCode() < 300);
             if ($canCache) {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -82,6 +82,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mock-cli', $config->get('api.oauth2_client_id'));
         $this->assertEquals('console.example.com', $config->get('detection.console_domain'));
         $this->assertEquals('.mock/applications.yaml', $config->get('service.applications_config_file'));
+        $this->assertEquals('X-Mock-Cluster', $config->get('detection.cluster_header'));
     }
 
     /**

--- a/tests/data/mock-cli-config.yaml
+++ b/tests/data/mock-cli-config.yaml
@@ -11,10 +11,11 @@ service:
   project_config_dir: .mock
   console_url: https://console.example.com
 
+  header_prefix: 'X-Mock' # this is the legacy config key; it will be moved to detection.cluster_header
+
 api:
   base_url: https://api.example.com
   disable_cache: true
 
 detection:
-  use_site_headers: false
   site_domains: [example.site]


### PR DESCRIPTION
This also removes the config key `detection.use_site_headers`.