### PR TITLE
Add commands to get and set build resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.82.1 <2.0",
+        "platformsh/client": ">=0.83.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d156e5f703fc0b034eb324eac5eff1a",
+    "content-hash": "c8954eaa7696ef050e10916cc7b4fee5",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -921,16 +921,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.82.1",
+            "version": "0.83.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "c667fa38485872e4127cf639ae15408be2126ee0"
+                "reference": "5c059693034c20c93bbf408222f6103cabe91b21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/c667fa38485872e4127cf639ae15408be2126ee0",
-                "reference": "c667fa38485872e4127cf639ae15408be2126ee0",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/5c059693034c20c93bbf408222f6103cabe91b21",
+                "reference": "5c059693034c20c93bbf408222f6103cabe91b21",
                 "shasum": ""
             },
             "require": {
@@ -962,9 +962,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.82.1"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.83.0"
             },
-            "time": "2024-04-29T20:08:00+00:00"
+            "time": "2024-05-21T12:55:28+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Application.php
+++ b/src/Application.php
@@ -241,6 +241,8 @@ class Application extends ParentApplication
         $commands[] = new Command\Resources\ResourcesGetCommand();
         $commands[] = new Command\Resources\ResourcesSizeListCommand();
         $commands[] = new Command\Resources\ResourcesSetCommand();
+        $commands[] = new Command\Resources\Build\BuildResourcesGetCommand();
+        $commands[] = new Command\Resources\Build\BuildResourcesSetCommand();
         $commands[] = new Command\RuntimeOperation\ListCommand();
         $commands[] = new Command\RuntimeOperation\RunCommand();
         $commands[] = new Command\SourceOperation\ListCommand();

--- a/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -18,7 +18,8 @@ class BuildResourcesGetCommand extends CommandBase
     protected function configure()
     {
         $this->setName('resources:build:get')
-            ->setAliases(['build-resources:get'])
+            ->setAliases(['build-resources:get', 'build-resources'])
+            ->setHiddenAliases(['resources:build', 'res:build'])
             ->setDescription('View the build resources of a project')
             ->addProjectOption();
         Table::configureInput($this->getDefinition(), $this->tableHeader);

--- a/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Platformsh\Cli\Command\Resources\Build;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Service\Table;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BuildResourcesGetCommand extends CommandBase
+{
+    protected $tableHeader = [
+        'cpu' => 'CPU',
+        'memory' => 'Memory (MB)',
+    ];
+
+    protected function configure()
+    {
+        $this->setName('resources:build:get')
+            ->setAliases(['build-resources:get'])
+            ->setDescription('View the build resources of a project')
+            ->addProjectOption();
+        Table::configureInput($this->getDefinition(), $this->tableHeader);
+        if ($this->config()->has('service.resources_help_url')) {
+            $this->setHelp('For more information on managing resources, see: <info>' . $this->config()->get('service.resources_help_url') . '</info>');
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input);
+        if (!$this->api()->supportsSizingApi($this->getSelectedProject())) {
+            $this->stdErr->writeln(sprintf('The flexible resources API is not enabled for the project %s.', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')));
+            return 1;
+        }
+
+        $project = $this->getSelectedProject();
+        $settings = $project->getSettings();
+
+        /** @var Table $table */
+        $table = $this->getService('table');
+
+        $isOriginalCommand = $input instanceof ArgvInput;
+
+        if (!$table->formatIsMachineReadable() && $isOriginalCommand) {
+            $this->stdErr->writeln(sprintf('Build resources for the project %s:', $this->api()->getProjectLabel($this->getSelectedProject())));
+        }
+
+        $rows = [
+            [
+                'cpu' => $settings['build_resources']['cpu'],
+                'memory' => $settings['build_resources']['memory'],
+            ],
+        ];
+
+        $table->render($rows, $this->tableHeader);
+
+        if (!$table->formatIsMachineReadable() && $isOriginalCommand) {
+            $executable = $this->config()->get('application.executable');
+            $this->stdErr->writeln('');
+            $this->stdErr->writeln(sprintf('Configure resources by running: <info>%s resources:build:set</info>', $executable));
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -19,7 +19,6 @@ class BuildResourcesGetCommand extends CommandBase
     {
         $this->setName('resources:build:get')
             ->setAliases(['build-resources:get', 'build-resources'])
-            ->setHiddenAliases(['resources:build', 'res:build'])
             ->setDescription('View the build resources of a project')
             ->addProjectOption();
         Table::configureInput($this->getDefinition(), $this->tableHeader);

--- a/src/Command/Resources/Build/BuildResourcesSetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesSetCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Platformsh\Cli\Command\Resources\Build;
+
+use Platformsh\Cli\Command\Resources\ResourcesCommandBase;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BuildResourcesSetCommand extends ResourcesCommandBase
+{
+    protected function configure()
+    {
+        $this->setName('resources:build:set')
+            ->setAliases(['build-resources:set'])
+            ->setDescription('Set the build resources of a project')
+            ->addOption('cpu', null, InputOption::VALUE_REQUIRED, 'Build CPU')
+            ->addOption('memory', null, InputOption::VALUE_REQUIRED, 'Build memory (in MB)')
+            ->addProjectOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->validateInput($input);
+        if (!$this->api()->supportsSizingApi($this->getSelectedProject())) {
+            $this->stdErr->writeln(sprintf('The flexible resources API is not enabled for the project %s.', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')));
+            return 1;
+        }
+
+        $project = $this->getSelectedProject();
+        $settings = $project->getSettings();
+
+        $cpuOption = $input->getOption('cpu');
+        $memoryOption = $input->getOption('memory');
+
+        /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+        $questionHelper = $this->getService('question_helper');
+
+        $validateCpu = function ($v) {
+            $f = (float) $v;
+            if ($f != $v) {
+                throw new RuntimeException('The CPU value must be a number');
+            }
+            return $f;
+        };
+        $validateMemory = function ($v) {
+            $i = (int) $v;
+            if ($i != $v) {
+                throw new RuntimeException('The memory value must be an integer');
+            }
+            return $i;
+        };
+
+        $this->stdErr->writeln('Update the build resources on the project: ' . $this->api()->getProjectLabel($project));
+        $this->stdErr->writeln('');
+
+        $newline = false;
+
+        if ($cpuOption !== null) {
+            $cpuOption = $validateCpu($cpuOption);
+        } else {
+            $cpuOption = $questionHelper->askInput(
+                'CPU size',
+                $settings['build_resources']['cpu'],
+                [],
+                $validateCpu
+            );
+            $newline = true;
+        }
+        if ($memoryOption !== null) {
+            $memoryOption = $validateMemory($memoryOption);
+        }
+        else {
+            $memoryOption = $questionHelper->askInput(
+                'Memory size in MB',
+                $settings['build_resources']['memory'],
+                [],
+                $validateMemory
+            );
+            $newline = true;
+        }
+        if ($newline) {
+            $this->stdErr->writeln('');
+        }
+
+        $updates = [];
+        if ($cpuOption !== $settings['build_resources']['cpu']) {
+            $updates['build_resources']['cpu'] = $cpuOption;
+        }
+        if ($memoryOption !== $settings['build_resources']['memory']) {
+            $updates['build_resources']['memory'] = $memoryOption;
+        }
+
+        if (empty($updates)) {
+            $this->stdErr->writeln('No changes were provided: nothing to update.');
+            return 0;
+        }
+
+        $this->summarizeChanges($updates['build_resources'], $settings['build_resources']);
+
+        $this->debug('Raw updates: ' . json_encode($updates, JSON_UNESCAPED_SLASHES));
+
+        $this->stdErr->writeln('');
+        if (!$questionHelper->confirm('Are you sure you want to continue?')) {
+            return 1;
+        }
+
+        $this->stdErr->writeln('');
+        $settings->update($updates);
+
+        $this->stdErr->writeln('The settings were successfully updated.');
+
+        return $this->runOtherCommand('resources:build:get', ['--project' => $project->id]);
+    }
+
+    /**
+     * Summarizes all the changes that would be made.
+     *
+     * @param array{cpu: int, memory: int} $updates
+     * @param array{cpu: int, memory: int} $current
+     * @return void
+     */
+    private function summarizeChanges(array $updates, array $current)
+    {
+        $this->stdErr->writeln('<options=bold>Summary of changes:</>');
+        $this->stdErr->writeln('  CPU: ' . $this->formatChange(
+            $current['cpu'],
+            isset($updates['cpu']) ? $updates['cpu'] : $current['cpu']
+        ));
+        $this->stdErr->writeln('  Memory: ' . $this->formatChange(
+            $current['memory'],
+            isset($updates['memory']) ? $updates['memory'] : $current['memory'],
+            ' MB'
+        ));
+    }
+}

--- a/src/Command/Resources/Build/BuildResourcesSetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesSetCommand.php
@@ -62,9 +62,10 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
         } else {
             $cpuOption = $questionHelper->askInput(
                 'CPU size',
-                $settings['build_resources']['cpu'],
+                $this->formatCPU($settings['build_resources']['cpu']),
                 [],
-                $validateCpu
+                $validateCpu,
+                'current: '
             );
             $newline = true;
         }
@@ -76,7 +77,8 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
                 'Memory size in MB',
                 $settings['build_resources']['memory'],
                 [],
-                $validateMemory
+                $validateMemory,
+                'current: '
             );
             $newline = true;
         }
@@ -125,8 +127,8 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
     {
         $this->stdErr->writeln('<options=bold>Summary of changes:</>');
         $this->stdErr->writeln('  CPU: ' . $this->formatChange(
-            $current['cpu'],
-            isset($updates['cpu']) ? $updates['cpu'] : $current['cpu']
+            $this->formatCPU($current['cpu']),
+            $this->formatCPU(isset($updates['cpu']) ? $updates['cpu'] : $current['cpu'])
         ));
         $this->stdErr->writeln('  Memory: ' . $this->formatChange(
             $current['memory'],

--- a/src/Command/Resources/Build/BuildResourcesSetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesSetCommand.php
@@ -87,8 +87,7 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
 
         $this->stdErr->writeln('');
 
-        $newline = false;
-        if ($cpuOption === null) {
+        if ($cpuOption === null && $memoryOption === null) {
             $cpuOption = $questionHelper->askInput(
                 'CPU size',
                 $this->formatCPU($settings['build_resources']['cpu']),
@@ -96,9 +95,7 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
                 $validateCpu,
                 'current: '
             );
-            $newline = true;
-        }
-        if ($memoryOption === null) {
+
             $memoryOption = $questionHelper->askInput(
                 'Memory size in MB',
                 $settings['build_resources']['memory'],
@@ -106,17 +103,14 @@ class BuildResourcesSetCommand extends ResourcesCommandBase
                 $validateMemory,
                 'current: '
             );
-            $newline = true;
-        }
-        if ($newline) {
             $this->stdErr->writeln('');
         }
 
         $updates = [];
-        if ($cpuOption !== $settings['build_resources']['cpu']) {
+        if ($cpuOption !== null && $cpuOption !== $settings['build_resources']['cpu']) {
             $updates['build_resources']['cpu'] = $cpuOption;
         }
-        if ($memoryOption !== $settings['build_resources']['memory']) {
+        if ($memoryOption !== null && $memoryOption !== $settings['build_resources']['memory']) {
             $updates['build_resources']['memory'] = $memoryOption;
         }
 

--- a/src/Command/Resources/ResourcesCommandBase.php
+++ b/src/Command/Resources/ResourcesCommandBase.php
@@ -174,8 +174,8 @@ class ResourcesCommandBase extends CommandBase
     /**
      * Formats a change in a value.
      *
-     * @param int|float|null $previousValue
-     * @param int|float|null $newValue
+     * @param int|float|string|null $previousValue
+     * @param int|float|string|null $newValue
      * @param string $suffix A unit suffix e.g. ' MB'
      *
      * @return string
@@ -191,5 +191,18 @@ class ResourcesCommandBase extends CommandBase
             $previousValue, $suffix,
             $newValue, $suffix
         );
+    }
+
+    /**
+     * Formats a CPU amount.
+     *
+     * @param int|float|string $unformatted
+     *
+     * @return string
+     *   A numeric (still comparable) string with 1 decimal place.
+     */
+    protected function formatCPU($unformatted)
+    {
+        return sprintf('%.1f', $unformatted);
     }
 }

--- a/src/Command/Resources/ResourcesCommandBase.php
+++ b/src/Command/Resources/ResourcesCommandBase.php
@@ -170,4 +170,26 @@ class ResourcesCommandBase extends CommandBase
         }
         return null;
     }
+
+    /**
+     * Formats a change in a value.
+     *
+     * @param int|float|null $previousValue
+     * @param int|float|null $newValue
+     * @param string $suffix A unit suffix e.g. ' MB'
+     *
+     * @return string
+     */
+    protected function formatChange($previousValue, $newValue, $suffix = '')
+    {
+        if ($previousValue === null || $newValue === $previousValue) {
+            return sprintf('<info>%s%s</info>', $newValue, $suffix);
+        }
+        return sprintf(
+            '%s from %s%s to <info>%s%s</info>',
+            $newValue > $previousValue ? '<fg=green>increasing</>' : '<fg=yellow>decreasing</>',
+            $previousValue, $suffix,
+            $newValue, $suffix
+        );
+    }
 }

--- a/src/Command/Resources/ResourcesGetCommand.php
+++ b/src/Command/Resources/ResourcesGetCommand.php
@@ -105,7 +105,7 @@ class ResourcesGetCommand extends ResourcesCommandBase
 
             if (isset($properties['container_profile']) && isset($containerProfiles[$properties['container_profile']][$properties['resources']['profile_size']])) {
                 $profileInfo = $containerProfiles[$properties['container_profile']][$properties['resources']['profile_size']];
-                $row['cpu'] = isset($profileInfo['cpu']) ? $profileInfo['cpu'] : '';
+                $row['cpu'] = isset($profileInfo['cpu']) ? $this->formatCPU($profileInfo['cpu']) : '';
                 $row['memory'] = isset($profileInfo['cpu']) ? $profileInfo['memory'] : '';
             }
 

--- a/src/Command/Resources/ResourcesSetCommand.php
+++ b/src/Command/Resources/ResourcesSetCommand.php
@@ -401,28 +401,6 @@ class ResourcesSetCommand extends ResourcesCommandBase
     }
 
     /**
-     * Formats a change in a value.
-     *
-     * @param int|float|null $previousValue
-     * @param int|float|null $newValue
-     * @param string $suffix A unit suffix e.g. ' MB'
-     *
-     * @return string
-     */
-    protected function formatChange($previousValue, $newValue, $suffix = '')
-    {
-        if ($previousValue === null || $newValue === $previousValue) {
-            return sprintf('<info>%s%s</info>', $newValue, $suffix);
-        }
-        return sprintf(
-            '%s from %s%s to <info>%s%s</info>',
-            $newValue > $previousValue ? '<fg=green>increasing</>' : '<fg=yellow>decreasing</>',
-            $previousValue, $suffix,
-            $newValue, $suffix
-        );
-    }
-
-    /**
      * Returns the group for a service (where it belongs in the deployment object).
      *
      * @param Service|WebApp|Worker $service

--- a/src/Command/Resources/ResourcesSetCommand.php
+++ b/src/Command/Resources/ResourcesSetCommand.php
@@ -376,8 +376,8 @@ class ResourcesSetCommand extends ResourcesCommandBase
             $newProperties = array_replace_recursive($properties, $updates);
             $newSizeInfo = $this->sizeInfo($newProperties, $containerProfiles);
             $this->stdErr->writeln('    CPU: ' . $this->formatChange(
-                $sizeInfo ? $sizeInfo['cpu'] : null,
-                $newSizeInfo['cpu']
+                $this->formatCPU($sizeInfo ? $sizeInfo['cpu'] : null),
+                $this->formatCPU($newSizeInfo['cpu'])
             ));
             $this->stdErr->writeln('    Memory: ' . $this->formatChange(
                 $sizeInfo ? $sizeInfo['memory'] : null,

--- a/src/Command/Resources/ResourcesSizeListCommand.php
+++ b/src/Command/Resources/ResourcesSizeListCommand.php
@@ -79,7 +79,7 @@ class ResourcesSizeListCommand extends ResourcesCommandBase
 
         $rows = [];
         foreach ($containerProfiles[$profile] as $sizeName => $sizeInfo) {
-            $rows[] = ['size' => $sizeName, 'cpu' => $sizeInfo['cpu'], 'memory' => $sizeInfo['memory']];
+            $rows[] = ['size' => $sizeName, 'cpu' => $this->formatCPU($sizeInfo['cpu']), 'memory' => $sizeInfo['memory']];
         }
 
         if (!$table->formatIsMachineReadable()) {

--- a/src/Service/QuestionHelper.php
+++ b/src/Service/QuestionHelper.php
@@ -169,14 +169,15 @@ class QuestionHelper extends BaseQuestionHelper
      * @param mixed    $default
      * @param array    $autoCompleterValues
      * @param callable $validator
+     * @param string   $defaultLabel
      *
      * @return string
      *   The user's answer.
      */
-    public function askInput($questionText, $default = null, array $autoCompleterValues = [], callable $validator = null)
+    public function askInput($questionText, $default = null, array $autoCompleterValues = [], callable $validator = null, $defaultLabel = 'default: ')
     {
         if ($default !== null) {
-            $questionText .= ' (default: <question>' . $default . '</question>)';
+            $questionText .= sprintf(' (%s<question>%s</question>)', $defaultLabel, $default);
         }
         $questionText .= ': ';
         $question = new Question($questionText, $default);


### PR DESCRIPTION
New commands:

* `resources:build:get` (aliased to `build-resources:get`)
* `resources:build:set` (aliased to `build-resources:set`)

Test for Upsun with:

```
# Download Upsun config
curl -s https://raw.githubusercontent.com/platformsh/cli/main/internal/config/upsun-cli.yaml > /tmp/upsun-cli.yaml

# Download the build for this PR
curl -s https://pr-1447-ryc5tsy-mpaw4nkgdwaea.eu-2.platformsh.site/platform.phar > /tmp/platform-pr-1447.phar

# Create an alias
alias upsun='CLI_CONFIG_FILE=/tmp/upsun-cli.yaml php /tmp/platform-pr-1447.phar'

# Then run the above commands as "upsun ..."
```

Test requirements are the same as the legacy CLI installation requirements:

> an operating system supported by PHP (Linux, OS X, or Windows) and PHP (5.5.9 or higher) installed, with the following extensions: curl, json, pcre, and phar.