### PR TITLE
Allow local OAuth listener to succeed on an alternative port

### DIFF
--- a/resources/oauth-listener/index.php
+++ b/resources/oauth-listener/index.php
@@ -69,7 +69,7 @@ class Listener
                 $this->reportError('Invalid returned code_challenge parameter');
                 return;
             }
-            if (!$this->sendToTerminal(['code' => $_GET['code']])) {
+            if (!$this->sendToTerminal(['code' => $_GET['code'], 'redirect_uri' => $this->localUrl])) {
                 $this->reportError('Failed to send authorization code back to terminal');
                 return;
             }

--- a/src/Command/Auth/BrowserLoginCommand.php
+++ b/src/Command/Auth/BrowserLoginCommand.php
@@ -248,7 +248,7 @@ class BrowserLoginCommand extends CommandBase
 
         // Using the authorization code, request an access token.
         $this->stdErr->writeln('Login information received. Verifying...');
-        $token = $this->getAccessToken($code, $codeVerifier, $localUrl);
+        $token = $this->getAccessToken($code, $codeVerifier, isset($response['redirect_uri']) ? $response['redirect_uri'] : $localUrl);
 
         // Finalize login: log out and save the new credentials.
         $this->api()->logout();


### PR DESCRIPTION
Persists the exact redirect URI that was used, between the authorize request and the token request.