### PR TITLE
Improve formatting of Solr and PostgreSQL URLs

### DIFF
--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -373,8 +373,12 @@ class Relationships implements InputConfiguringInterface
             $parts['query'] = (new Query($parts['query']))->__toString();
         }
 
+        // Special cases for Solr.
         if (isset($parts['scheme']) && $parts['scheme'] === 'solr') {
             $parts['scheme'] = 'http';
+            if (isset($parts['path']) && \dirname($parts['path']) === '/solr') {
+                $parts['path'] = '/solr/';
+            }
         }
 
         return \GuzzleHttp\Url::buildUrl($parts);

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -373,12 +373,16 @@ class Relationships implements InputConfiguringInterface
             $parts['query'] = (new Query($parts['query']))->__toString();
         }
 
-        // Special cases for Solr.
+        // Special case #1: Solr.
         if (isset($parts['scheme']) && $parts['scheme'] === 'solr') {
             $parts['scheme'] = 'http';
             if (isset($parts['path']) && \dirname($parts['path']) === '/solr') {
                 $parts['path'] = '/solr/';
             }
+        }
+        // Special case #2: PostgreSQL.
+        if (isset($parts['scheme']) && $parts['scheme'] === 'pgsql') {
+            $parts['scheme'] = 'postgresql';
         }
 
         return \GuzzleHttp\Url::buildUrl($parts);


### PR DESCRIPTION
Adds a special case for Solr URLs (fixes #1443)

and also PostgreSQL - changing `pgsql://` to `postgresql://`