### PR TITLE
Update backup:restore command resources options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.84.0 <2.0",
+        "platformsh/client": ">=0.85.0 <2.0",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10a71f98d1b34e7a7ea8562facce2adf",
+    "content-hash": "cd92506c5bd717cea914d8fdf106fd8d",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -921,16 +921,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.84.0",
+            "version": "0.85.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "6a3920df8de4588e911a575d0c9b6e4293c33bb3"
+                "reference": "36425b70260021b230352a05b572ed15e2eb5bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/6a3920df8de4588e911a575d0c9b6e4293c33bb3",
-                "reference": "6a3920df8de4588e911a575d0c9b6e4293c33bb3",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/36425b70260021b230352a05b572ed15e2eb5bf2",
+                "reference": "36425b70260021b230352a05b572ed15e2eb5bf2",
                 "shasum": ""
             },
             "require": {
@@ -962,9 +962,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.84.0"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.85.0"
             },
-            "time": "2024-05-23T15:33:40+00:00"
+            "time": "2024-07-01T19:03:46+00:00"
         },
         {
             "name": "platformsh/console-form",

--- a/src/Command/Backup/BackupRestoreCommand.php
+++ b/src/Command/Backup/BackupRestoreCommand.php
@@ -21,7 +21,10 @@ class BackupRestoreCommand extends CommandBase
             ->addOption('branch-from', null, InputOption::VALUE_REQUIRED, 'If the --target does not yet exist, this specifies the parent of the new environment')
             ->addOption('no-code', null, InputOption::VALUE_NONE, 'Do not restore code, only data.')
             ->addHiddenOption('restore-code', null, InputOption::VALUE_NONE, '[DEPRECATED] This option no longer has an effect.');
-        $this->addResourcesInitOption(['parent', 'default', 'minimum']);
+        if ($this->config()->get('api.sizing')) {
+            $this->addOption('no-resources', null, InputOption::VALUE_NONE, "Do not override the target's existing resource settings.");
+            $this->addResourcesInitOption(['backup', 'parent', 'default', 'minimum']);
+        }
         $this->addProjectOption()
              ->addEnvironmentOption()
              ->addWaitOptions();

--- a/src/Command/Backup/BackupRestoreCommand.php
+++ b/src/Command/Backup/BackupRestoreCommand.php
@@ -126,6 +126,7 @@ class BackupRestoreCommand extends CommandBase
                 ->setEnvironmentName($targetName)
                 ->setBranchFrom($branchFrom)
                 ->setRestoreCode($input->getOption('no-code') ? false : null)
+                ->setRestoreResources($input->getOption('no-resources') ? false : null)
                 ->setResourcesInit($resourcesInit)
         );
 


### PR DESCRIPTION
Closes https://github.com/platformsh/cli/issues/190

```
Usage:
 upsun backup:restore [--target TARGET] [--branch-from BRANCH-FROM] [--no-code] [--no-resources] [--resources-init RESOURCES-INIT] [-p|--project PROJECT] [-e|--environment ENVIRONMENT] [-W|--no-wait] [--wait] [--] [<backup>]

Arguments:
  backup                               The ID of the backup. Defaults to the most recent one

Options:
      --target=TARGET                  The environment to restore to. Defaults to the backup's current environment
      --branch-from=BRANCH-FROM        If the --target does not yet exist, this specifies the parent of the new
                                       environment
      --no-code                        Do not restore code, only data.
      --no-resources                   Do not override the target's existing resource settings.
      --resources-init=RESOURCES-INIT  Set the resources to use for new services: backup, parent, default or minimum.
                                       If not set, "backup" will be used.
```