### PR TITLE
Convert Windows filenames for SSH config

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -302,6 +302,9 @@ ssh:
   # though a recommendation will be displayed.
   write_user_config: null
 
+  # Whether to convert file paths from Windows to UNIX format in SSH config.
+  convert_windows_paths: true
+
   # Whether auto-generated SSH certificate identities should be added to the SSH agent.
   # Enabling this may be useful for those who use agent forwarding.
   add_to_agent: false

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -197,11 +197,21 @@ class SshConfig {
      */
     public function formatFilePath($path)
     {
-        // Escape paths containing a space.
+        // Convert absolute Windows paths (e.g. beginning "C:\") to Unix paths.
+        // OpenSSH apparently treats the Windows format as a relative path.
+        if (OsUtil::isWindows() && $this->config->getWithDefault('ssh.convert_windows_paths', true)) {
+            if (\strlen($path) >= 2 && $path[1] === ':' && \preg_match('#^[A-Z]#', $path)) {
+                $path = '/' . \strtolower($path[0]) . '/' . \ltrim(\substr($path, 2), '\\/');
+                $path = \str_replace('\\', '/', $path);
+            }
+        }
+
+        // Quote all paths containing a space.
         if (\strpos($path, ' ') !== false) {
             // The three quote marks in the middle mean: end quote, literal quote mark, start quote.
-            return '"' . \str_replace('"', '"""', $path) . '"';
+            $path = '"' . \str_replace('"', '"""', $path) . '"';
         }
+
         return $path;
     }
 


### PR DESCRIPTION
Restore the previous behavior by setting the environment variable `PLATFORMSH_CLI_SSH_CONVERT_WINDOWS_PATHS` to `0`.