### PR TITLE
Auto-censor the Authorization header in curl commands

### DIFF
--- a/src/Service/CurlCli.php
+++ b/src/Service/CurlCli.php
@@ -104,12 +104,17 @@ class CurlCli implements InputConfiguringInterface {
             $commandline .= ' --silent --show-error';
         }
 
-        $stdErr->writeln(sprintf('Running command: <info>%s</info>', str_replace($token, '[token]', $commandline)), OutputInterface::VERBOSITY_VERBOSE);
+        // Censor the access token: this can be applied to verbose output.
+        $censor = function ($str) use ($token) {
+            return str_replace($token, '[token]', $str);
+        };
+
+        $stdErr->writeln(sprintf('Running command: <info>%s</info>', $censor($commandline)), OutputInterface::VERBOSITY_VERBOSE);
 
         $process = new Process($commandline);
-        $process->run(function ($type, $buffer) use ($stdErr, $token, $output) {
+        $process->run(function ($type, $buffer) use ($stdErr, $censor, $output) {
             if ($type === Process::ERR) {
-                $stdErr->write(str_replace($token, '[token]', $buffer));
+                $stdErr->write($censor($buffer));
             } else {
                 $output->write($buffer);
             }

--- a/src/Service/CurlCli.php
+++ b/src/Service/CurlCli.php
@@ -112,7 +112,7 @@ class CurlCli implements InputConfiguringInterface {
         $stdErr->writeln(sprintf('Running command: <info>%s</info>', $censor($commandline)), OutputInterface::VERBOSITY_VERBOSE);
 
         $process = new Process($commandline);
-        $process->run(function ($type, $buffer) use ($stdErr, $censor, $output) {
+        $process->run(function ($type, $buffer) use ($censor, $output, $stdErr) {
             if ($type === Process::ERR) {
                 $stdErr->write($censor($buffer));
             } else {

--- a/src/Service/CurlCli.php
+++ b/src/Service/CurlCli.php
@@ -107,16 +107,13 @@ class CurlCli implements InputConfiguringInterface {
         $stdErr->writeln(sprintf('Running command: <info>%s</info>', str_replace($token, '[token]', $commandline)), OutputInterface::VERBOSITY_VERBOSE);
 
         $process = new Process($commandline);
-        $process->run(function ($type, $buffer) use ($output, $stdErr) {
+        $process->run(function ($type, $buffer) use ($stdErr, $token) {
             if ($type === Process::ERR) {
-                if (stripos($buffer, 'Authorization: ') !== false) {
-                    $buffer = preg_replace('/(Authorization:( [a-z0-9-]+)?) \S+/i', '$1 [credentials]', $buffer);
-                }
-                $stdErr->write($buffer);
+                $stdErr->write(str_replace($token, '[token]', $buffer));
             }
         });
 
-        $output->writeln($process->getOutput());
+        $output->write($process->getOutput());
 
         return $process->getExitCode();
     }

--- a/src/Service/CurlCli.php
+++ b/src/Service/CurlCli.php
@@ -107,13 +107,13 @@ class CurlCli implements InputConfiguringInterface {
         $stdErr->writeln(sprintf('Running command: <info>%s</info>', str_replace($token, '[token]', $commandline)), OutputInterface::VERBOSITY_VERBOSE);
 
         $process = new Process($commandline);
-        $process->run(function ($type, $buffer) use ($stdErr, $token) {
+        $process->run(function ($type, $buffer) use ($stdErr, $token, $output) {
             if ($type === Process::ERR) {
                 $stdErr->write(str_replace($token, '[token]', $buffer));
+            } else {
+                $output->write($buffer);
             }
         });
-
-        $output->write($process->getOutput());
 
         return $process->getExitCode();
     }


### PR DESCRIPTION
Produces output like:

```
> GET /users/me HTTP/2
> Host: api.platform.sh
> User-Agent: curl/8.2.1
> Accept: */*
> Accept-Encoding: deflate, gzip, br, zstd
> Authorization: Bearer [credentials]
```