### PR TITLE
Add Unix paths for OpenSSH on Windows

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -302,6 +302,13 @@ ssh:
   # though a recommendation will be displayed.
   write_user_config: null
 
+  # Whether to convert file paths from Windows to UNIX format in SSH config.
+  #
+  # Valid values: 'both' (configure both Windows and UNIX paths for higher
+  # compatibility), 'convert' (only configure in UNIX format), or 'raw' (do
+  # not convert filenames).
+  windows_paths: both
+
   # Whether auto-generated SSH certificate identities should be added to the SSH agent.
   # Enabling this may be useful for those who use agent forwarding.
   add_to_agent: false


### PR DESCRIPTION
Restore the previous version's behavior by setting the environment variable `PLATFORMSH_CLI_SSH_WINDOWS_PATHS=raw` (or replace `PLATFORMSH_CLI_` with the correct vendor prefix)