### PR TITLE
Extend the request timeout for /environments requests

### DIFF
--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -745,9 +745,13 @@ class Api
         if ($refresh === false && !$cached) {
             return [];
         } elseif ($refresh || !$cached) {
-            $environments = [];
             $toCache = [];
-            foreach ($project->getEnvironments() as $environment) {
+
+            // Fetch environments with double the default timeout.
+            $environments = Environment::getCollection($project->getLink('environments'), 0, [
+                'timeout' => 2 * $this->config->getWithDefault('api.default_timeout', 30),
+            ], $this->getHttpClient());
+            foreach ($environments as $environment) {
                 $environments[$environment->id] = $environment;
                 $toCache[$environment->id] = $environment->getData();
             }


### PR DESCRIPTION
Requests /environments with double the default API request timeout (60 rather than 30 seconds). This is by far the slowest API endpoint, arguably for good reasons, but it's also the entrypoint for a lot of commands, and the current default timeout is being reached quite frequently.