### PR TITLE
Support listing teams for a single project

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -203,6 +203,7 @@ api:
   projects_ttl: 600
   environments_ttl: 120
   users_ttl: 600
+  orgs_ttl: 600
 
   # The default timeout for API requests, in seconds.
   # Overridden by the {application.env_prefix}DEFAULT_TIMEOUT env var.

--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,7 @@ api:
   organizations: true
   user_verification: true
   metrics: true
+  teams: true
 
   vendor_filter: 'platformsh'
 

--- a/src/Command/Team/TeamCommandBase.php
+++ b/src/Command/Team/TeamCommandBase.php
@@ -143,7 +143,7 @@ class TeamCommandBase extends CommandBase
     protected function loadTeams(Organization $organization, $fetchAllPages = true, $params = [])
     {
         $httpClient = $this->api()->getHttpClient();
-        $options = ['query' => ['filter[organization_id]' => $organization->id] + $params];
+        $options = ['query' => array_merge(['filter[organization_id]' => $organization->id, 'sort' => 'label'], $params)];
         $url = '/teams';
         /** @var Team[] $teams */
         $teams = [];

--- a/src/Command/Team/TeamListCommand.php
+++ b/src/Command/Team/TeamListCommand.php
@@ -1,9 +1,14 @@
 <?php
 namespace Platformsh\Cli\Command\Team;
 
+use GuzzleHttp\Exception\BadResponseException;
+use Platformsh\Cli\Console\ProgressMessage;
 use Platformsh\Cli\Model\ProjectRoles;
 use Platformsh\Cli\Service\PropertyFormatter;
 use Platformsh\Cli\Service\Table;
+use Platformsh\Cli\Util\OsUtil;
+use Platformsh\Client\Exception\ApiResponseException;
+use Platformsh\Client\Model\Project;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,6 +23,7 @@ class TeamListCommand extends TeamCommandBase
         'project_permissions' => 'Permissions',
         'created_at' => 'Created at',
         'updated_at' => 'Updated at',
+        'granted_at' => 'Granted at',
     ];
     private $defaultColumns = ['id', 'label', 'member_count', 'project_count', 'project_permissions'];
 
@@ -32,9 +38,13 @@ class TeamListCommand extends TeamCommandBase
             ->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'The number of items to display per page. Use 0 to disable pagination.')
             ->addOption('sort', null, InputOption::VALUE_REQUIRED, 'A team property to sort by', 'label')
             ->addOption('reverse', null, InputOption::VALUE_NONE, 'Sort in reverse order')
+            ->addOption('all', 'A', InputOption::VALUE_NONE, 'List all teams in the organization (regardless of a selected project)')
             ->addOrganizationOptions(true);
         PropertyFormatter::configureInput($this->getDefinition());
         Table::configureInput($this->getDefinition(), $this->tableHeader, $this->defaultColumns);
+        $this->addExample('List teams (in the current project, if any)');
+        $this->addExample('List all teams in an organization', '--all');
+        $this->addExample('List teams with access to a specified project, including when they were added', '--project myProjectId --columns +granted_at');
     }
 
     /**
@@ -62,11 +72,25 @@ class TeamListCommand extends TeamCommandBase
             $params['page[size]'] = $count;
         }
 
-        $teams = $this->loadTeams($organization, $fetchAllPages, $params);
-
         $executable = $this->config()->get('application.executable');
+
+        // Fetch teams for a specific project.
+        $projectSpecific = !$input->getOption('all') && $this->hasSelectedProject();
+        if ($projectSpecific) {
+            $teamsOnProject = $this->loadTeamsOnProject($this->getSelectedProject());
+            if (!$teamsOnProject) {
+                $this->stdErr->writeln(sprintf('No teams found on the project %s.', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')));
+                $this->stdErr->writeln('');
+                $this->stdErr->writeln(\sprintf('To list all teams in the organization, run: <info>%s teams --all</info>', $executable));
+                $this->stdErr->writeln(\sprintf('To add this project to a team, run: <info>%s team:project:add %s</info>', $executable, OsUtil::escapeShellArg($this->getSelectedProject()->id)));
+                return 1;
+            }
+            $params['filter[id][in]'] = implode(',', array_keys($teamsOnProject));
+        }
+
+        $teams = $this->loadTeams($organization, $fetchAllPages, $params);
         if (empty($teams)) {
-            $this->stdErr->writeln('No teams found.');
+            $this->stdErr->writeln('No teams found');
             if ($this->config()->isCommandEnabled('team:create')) {
                 $this->stdErr->writeln('');
                 $this->stdErr->writeln(\sprintf('To create a new team, run: <info>%s team:create</info>', $executable));
@@ -74,9 +98,9 @@ class TeamListCommand extends TeamCommandBase
             return 1;
         }
 
-        /** @var \Platformsh\Cli\Service\Table $table */
+        /** @var Table $table */
         $table = $this->getService('table');
-        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
+        /** @var PropertyFormatter $formatter */
         $formatter = $this->getService('property_formatter');
 
         $machineReadable = $table->formatIsMachineReadable();
@@ -93,23 +117,65 @@ class TeamListCommand extends TeamCommandBase
                 'project_permissions' => $rolesUtil->formatPermissions($team->project_permissions, $machineReadable),
                 'created_at' => $formatter->format($team->created_at, 'created_at'),
                 'updated_at' => $formatter->format($team->created_at, 'updated_at'),
+                'granted_at' => isset($teamsOnProject[$team->id]) ? $formatter->format($teamsOnProject[$team->id], 'granted_at') : '',
             ];
             $rows[] = $row;
         }
 
         if (!$machineReadable) {
-            $this->stdErr->writeln(sprintf('Teams in the organization %s:', $this->api()->getOrganizationLabel($organization)));
+            if ($projectSpecific) {
+                $this->stdErr->writeln(sprintf('Teams with access to the project %s:', $this->api()->getProjectLabel($this->getSelectedProject())));
+            } else {
+                $this->stdErr->writeln(sprintf('Teams in the organization %s:', $this->api()->getOrganizationLabel($organization)));
+            }
         }
 
         $table->render($rows, $this->tableHeader, $this->defaultColumns);
 
         if (!$machineReadable) {
             $this->stdErr->writeln('');
+            if ($projectSpecific) {
+                $this->stdErr->writeln(\sprintf('To list all teams in the organization, run: <info>%s teams --all</info>', $executable));
+            }
             $this->stdErr->writeln(\sprintf('To list team projects, run: <info>%s team:projects</info>', $executable));
             $this->stdErr->writeln(\sprintf('To list team users, run: <info>%s team:users</info>', $executable));
             $this->stdErr->writeln(\sprintf('To see all team commands run: <info>%s list team</info>', $executable));
         }
 
         return 0;
+    }
+
+    /**
+     * Loads the information of teams that have access to a single project.
+     *
+     * @param Project $project The project.
+     *
+     * @return array<string, string>
+     *     An array mapping team ID to the granted_at date of the team.
+     */
+    private function loadTeamsOnProject(Project $project)
+    {
+        $httpClient = $this->api()->getHttpClient();
+        $url = $project->getUri() . '/team-access';
+        $info = [];
+        $progress = new ProgressMessage($this->stdErr);
+        $pageNumber = 1;
+        do {
+            if ($pageNumber > 1) {
+                $progress->showIfOutputDecorated(sprintf('Loading project teams (page %d)...', $pageNumber));
+            }
+            try {
+                $data = $httpClient->get($url)->json();
+            } catch (BadResponseException $e) {
+                throw ApiResponseException::create($e->getRequest(), $e->getResponse(), $e);
+            }
+            foreach ($data['items'] as $item) {
+                $info[$item['team_id']] = $item['granted_at'];
+            }
+            $progress->done();
+            $url = isset($data['_links']['next']['href']) ? $data['_links']['next']['href'] : null;
+            $pageNumber++;
+        } while ($url);
+        return $info;
     }
 }

--- a/src/Command/User/UserListCommand.php
+++ b/src/Command/User/UserListCommand.php
@@ -101,10 +101,17 @@ class UserListCommand extends UserCommandBase
         if (!$table->formatIsMachineReadable()) {
             $this->stdErr->writeln('');
             $executable = $this->config()->get('application.executable');
-            $this->stdErr->writeln("To add a new user to the project, run: <info>$executable user:add [email]</info>");
+            $this->stdErr->writeln("To add a new user to the project, run: <info>$executable user:add</info>");
             $this->stdErr->writeln('');
-            $this->stdErr->writeln("To view a user's role(s), run: <info>$executable user:get [email]</info>");
-            $this->stdErr->writeln("To change a user's role(s), run: <info>$executable user:update [email]</info>");
+            $this->stdErr->writeln("To view a user's role(s), run: <info>$executable user:get</info>");
+            $this->stdErr->writeln("To change a user's role(s), run: <info>$executable user:update</info>");
+            if ($this->centralizedPermissionsEnabled() && $this->config()->get('api.teams')) {
+                $organization = $this->api()->getOrganizationById($project->getProperty('organization'));
+                if (in_array('teams', $organization->capabilities) && $organization->hasLink('members')) {
+                    $this->stdErr->writeln('');
+                    $this->stdErr->writeln(sprintf("To list teams with access to the project, run: <info>$executable teams -p %s</info>", $project->id));
+                }
+            }
         }
 
         return 0;

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -1032,11 +1032,11 @@ class Api
     public static function sortResources(array &$resources, $propertyPath, $reverse = false)
     {
         uasort($resources, function (ApiResource $a, ApiResource $b) use ($propertyPath, $reverse) {
-            $cmp = Sort::compare(
+            return Sort::compare(
                 static::getNestedProperty($a, $propertyPath, false),
-                static::getNestedProperty($b, $propertyPath, false)
+                static::getNestedProperty($b, $propertyPath, false),
+                $reverse
             );
-            return $reverse ? -$cmp : $cmp;
         });
     }
 
@@ -1541,9 +1541,21 @@ class Api
         if ($organization) {
             $data = $organization->getData();
             $data['_url'] = $organization->getUri();
-            $this->cache->save($cacheKey, $data, $this->config->getWithDefault('api.orgs_ttl', 3600));
+            $this->cache->save($cacheKey, $data, $this->config->getWithDefault('api.orgs_ttl', 600));
         }
         return $organization;
+    }
+
+    /**
+     * Loads an organization by name, with caching.
+     *
+     * @param string $name
+     * @param bool $reset
+     * @return Organization|false
+     */
+    public function getOrganizationByName($name, $reset = false)
+    {
+        return $this->getOrganizationById('name=' . $name, $reset);
     }
 
     /**

--- a/src/Util/Sort.php
+++ b/src/Util/Sort.php
@@ -12,15 +12,18 @@ final class Sort
      *
      * @param mixed $a
      * @param mixed $b
+     * @param bool $reverse
      * @return int
      */
-    public static function compare($a, $b)
+    public static function compare($a, $b, $reverse = false)
     {
         if (\is_string($a)) {
-            return \strnatcasecmp($a, $b);
+            $value = \strnatcasecmp($a, $b);
+        } else {
+            // TODO replace with spaceship operator for PHP 7+
+            $value = $a == $b ? 0 : ($a > $b ? 1 : -1);
         }
-        // TODO replace with spaceship operator for PHP 7+
-        return $a == $b ? 0 : ($a > $b ? 1 : -1);
+        return $reverse ? -$value : $value;
     }
 
     /**
@@ -58,8 +61,7 @@ final class Sort
             if (!property_exists($a, $property) || !property_exists($b, $property)) {
                 throw new \InvalidArgumentException('Cannot sort: property not found: ' . $property);
             }
-            $cmp = self::compare($a->$property, $b->$property);
-            return $reverse ? -$cmp : $cmp;
+            return self::compare($a->$property, $b->$property, $reverse);
         });
     }
 }


### PR DESCRIPTION
The `team:list` (`teams`) command will now filter the teams list to those with
access to the selected project, if any. The project is selected in the normal
way, e.g. by `--project` (`-p`), or the current Git repository.

Use the `--all` option to list all the teams in the organization.

Add the `granted_at` column (`--columns +granted_at`) to see when the team was
added to the project.

This MR also adds a bit more local caching for organization data.