### PR TITLE
Re-allow output from "ssh-cert:load --refresh-only", now that quiet mode works

### DIFF
--- a/src/Command/SshCert/SshCertLoadCommand.php
+++ b/src/Command/SshCert/SshCertLoadCommand.php
@@ -14,9 +14,7 @@ class SshCertLoadCommand extends CommandBase
     {
         $this
             ->setName('ssh-cert:load')
-            ->addOption('refresh-only', null, InputOption::VALUE_NONE,
-                'Only refresh the certificate, if necessary (do not write SSH config).'
-                . ' Unless verbose mode is used, this will not output messages.')
+            ->addOption('refresh-only', null, InputOption::VALUE_NONE, 'Only refresh the certificate, if necessary (do not write SSH config)')
             ->addOption('new', null, InputOption::VALUE_NONE, 'Force the certificate to be refreshed')
             ->addOption('new-key', null, InputOption::VALUE_NONE, 'Force a new key pair to be generated')
             ->setDescription('Generate an SSH certificate');
@@ -47,7 +45,7 @@ class SshCertLoadCommand extends CommandBase
 
         $refresh = true;
         if (getenv(Ssh::SSH_NO_REFRESH_ENV_VAR)) {
-            if ($refreshOnly && !$this->stdErr->isVerbose()) {
+            if ($refreshOnly && $this->stdErr->isQuiet()) {
                 return 0;
             }
             $this->stdErr->writeln(sprintf('Not refreshing SSH certificate (<comment>%s</comment> variable is set)', Ssh::SSH_NO_REFRESH_ENV_VAR));
@@ -58,7 +56,7 @@ class SshCertLoadCommand extends CommandBase
             && !$input->getOption('new')
             && !$input->getOption('new-key')
             && $certifier->isValid($sshCert)) {
-            if ($refreshOnly && !$this->stdErr->isVerbose()) {
+            if ($refreshOnly && $this->stdErr->isQuiet()) {
                 return 0;
             }
             $this->stdErr->writeln('A valid SSH certificate exists');
@@ -73,7 +71,7 @@ class SshCertLoadCommand extends CommandBase
             if (!$sshConfig->checkRequiredVersion()) {
                 return 1;
             }
-            if ($refreshOnly && !$this->stdErr->isVerbose()) {
+            if ($refreshOnly && $this->stdErr->isQuiet()) {
                 $certifier->generateCertificate($sshCert, $input->getOption('new-key'));
                 return 0;
             }

--- a/src/Service/SshConfig.php
+++ b/src/Service/SshConfig.php
@@ -96,7 +96,7 @@ class SshConfig {
         $certificate = $this->certifier->getExistingCertificate();
         if ($certificate) {
             $executable = $this->config->get('application.executable');
-            $refreshCommand = sprintf('%s ssh-cert:load --refresh-only --yes', $executable);
+            $refreshCommand = sprintf('%s ssh-cert:load --refresh-only --yes --quiet', $executable);
 
             // On shells where it might work (POSIX compliant), skip refreshing
             // the certificate when the CLI_SSH_NO_REFRESH env var is set to 1.


### PR DESCRIPTION
This partially reverts 29a92850a2ce8a4f583e23bba75dcf1fdaad44c3