### PR TITLE
Rename "web" command to "console"

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -285,7 +285,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Variable\VariableUpdateCommand();
         $commands[] = new Command\Version\VersionListCommand();
         $commands[] = new Command\WelcomeCommand();
-        $commands[] = new Command\WebCommand();
+        $commands[] = new Command\WebConsoleCommand();
         $commands[] = new Command\WinkyCommand();
         $commands[] = new Command\Worker\WorkerListCommand();
 

--- a/src/Command/WebConsoleCommand.php
+++ b/src/Command/WebConsoleCommand.php
@@ -6,15 +6,15 @@ use Platformsh\Cli\Service\Url;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class WebCommand extends CommandBase
+class WebConsoleCommand extends CommandBase
 {
 
     protected function configure()
     {
-        $hasConsole = $this->config()->has('service.console_url');
         $this
-            ->setName('web')
-            ->setDescription($hasConsole ? 'Open the project in the Web Console' : 'Open the project in the Web UI');
+            ->setName('console')
+            ->setHiddenAliases(['web'])
+            ->setDescription('Open the project in the Console');
         Url::configureInput($this->getDefinition());
         $this->addProjectOption()
              ->addEnvironmentOption();


### PR DESCRIPTION
- Keeps "web" as a hidden alias
- Keeps potential backwards compatibility when the `service.console_url` is not configured - perhaps this config could be made compulsory in another step