### PR TITLE
Add --skip-ssl to mariadb and mysql command invocations by default

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -269,6 +269,10 @@ api:
   # The timeout in seconds for a "git push" command. Set to null for no timeout.
   git_push_timeout: 3600
 
+sql:
+  # Pass the --skip-ssl option to mysql, mariadb, mysqldump and mariadb-dump.
+  skip_ssl: true
+
 ssh:
   ## Wildcard domains for SSH configuration.
   ## This is also used to detect whether to run diagnostics on an SSH connection error.

--- a/services.yaml
+++ b/services.yaml
@@ -118,7 +118,7 @@ services:
 
     relationships:
         class:     '\Platformsh\Cli\Service\Relationships'
-        arguments: ['@remote_env_vars']
+        arguments: ['@config', '@remote_env_vars']
 
     rsync:
       class:     '\Platformsh\Cli\Service\Rsync'

--- a/src/Service/Relationships.php
+++ b/src/Service/Relationships.php
@@ -16,13 +16,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Relationships implements InputConfiguringInterface
 {
 
+    protected $config;
     protected $envVarService;
 
     /**
      * @param RemoteEnvVars $envVarService
      */
-    public function __construct(RemoteEnvVars $envVarService)
+    public function __construct(Config $config, RemoteEnvVars $envVarService)
     {
+        $this->config = $config;
         $this->envVarService = $envVarService;
     }
 
@@ -302,6 +304,9 @@ class Relationships implements InputConfiguringInterface
                     OsUtil::escapePosixShellArg($database['host']),
                     $database['port']
                 );
+                if ($this->config->get('sql.skip_ssl')) {
+                    $args .= ' --skip-ssl';
+                }
                 if ($schema !== '') {
                     $args .= ' ' . OsUtil::escapePosixShellArg($schema);
                 }


### PR DESCRIPTION
MariaDB's client has [now added SSL enforcement](https://mariadb.com/kb/en/securing-connections-for-client-and-server/). The client (installed on the app server) may diverge in version and thus be a later version than the server (service), so SSL will start being enforced in the client before it is supported or enforced on the server.