### PR TITLE
Add environment deploy command and staged activities

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -921,16 +921,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.87.0",
+            "version": "0.88.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "3ba1dde15d3fb34568c87f8b6a84515646e9c880"
+                "reference": "5bd737d40743d97ab1883d6a6e762abddaa7b121"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/3ba1dde15d3fb34568c87f8b6a84515646e9c880",
-                "reference": "3ba1dde15d3fb34568c87f8b6a84515646e9c880",
+                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/5bd737d40743d97ab1883d6a6e762abddaa7b121",
+                "reference": "5bd737d40743d97ab1883d6a6e762abddaa7b121",
                 "shasum": ""
             },
             "require": {
@@ -962,9 +962,9 @@
             "description": "Platform.sh API client",
             "support": {
                 "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.87.0"
+                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.88.0"
             },
-            "time": "2024-11-14T08:02:39+00:00"
+            "time": "2025-05-14T14:08:57+00:00"
         },
         {
             "name": "platformsh/console-form",
@@ -4060,14 +4060,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.5.9",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "5.5.9"
     },

--- a/go-tests/environment_deploy_test.go
+++ b/go-tests/environment_deploy_test.go
@@ -35,10 +35,9 @@ func TestEnvironmentDeploy(t *testing.T) {
 	f := newCommandFactory(t, apiServer.URL, authServer.URL)
 	f.Run("cc")
 
-	assertTrimmed(t, `Nothing to deploy`, f.Run("env:deploy", "-p", projectID, "-e", "main"))
-
-	created, _ := time.Parse(time.RFC3339, "2014-04-01T10:00:00Z")
-	updated, _ := time.Parse(time.RFC3339, "2014-04-01T11:00:00Z")
+	created1, _ := time.Parse(time.RFC3339, "2014-04-01T10:00:00Z")
+	created2, _ := time.Parse(time.RFC3339, "2014-04-02T10:00:00Z")
+	updated, _ := time.Parse(time.RFC3339, "2014-04-02T11:00:00Z")
 	apiHandler.SetProjectActivities(projectID, []*mockapi.Activity{
 		{
 			ID:                "act1",
@@ -50,7 +49,7 @@ func TestEnvironmentDeploy(t *testing.T) {
 			Environments:      []string{"main"},
 			Description:       "<user>Mock User</user> pushed to <environment>main</environment>",
 			Text:              "Mock User pushed to main",
-			CreatedAt:         created,
+			CreatedAt:         created1,
 			UpdatedAt:         updated,
 		}, {
 			ID:                "act2",
@@ -62,20 +61,19 @@ func TestEnvironmentDeploy(t *testing.T) {
 			Environments:      []string{"main"},
 			Description:       "<user>Mock User</user> created variable <variable>X</variable> on environment <environment>main</environment>",
 			Text:              "Mock User created variable X on environment main",
-			CreatedAt:         created,
+			CreatedAt:         created2,
 			UpdatedAt:         updated,
 		},
 	})
 
 	assertTrimmed(t, `
-You are about to deploy the following changes on the environment main:
 +------+-------------------------+---------------------------------------------+-----------------------------+---------+
 | ID   | Created                 | Description                                 | Type                        | Result  |
 +------+-------------------------+---------------------------------------------+-----------------------------+---------+
+| act2 | 2014-04-02T10:00:00+00: | Mock User created variable X on environment | environment.variable.create | success |
+|      | 00                      | main                                        |                             |         |
 | act1 | 2014-04-01T10:00:00+00: | Mock User pushed to main                    | environment.push            | success |
 |      | 00                      |                                             |                             |         |
-| act2 | 2014-04-01T10:00:00+00: | Mock User created variable X on environment | environment.variable.create | success |
-|      | 00                      | main                                        |                             |         |
 +------+-------------------------+---------------------------------------------+-----------------------------+---------+
 `, f.Run("env:deploy", "-p", projectID, "-e", "main"))
 }

--- a/go-tests/environment_deploy_test.go
+++ b/go-tests/environment_deploy_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/platformsh/cli/pkg/mockapi"
+)
+
+func TestEnvironmentDeploy(t *testing.T) {
+	authServer := mockapi.NewAuthServer(t)
+	defer authServer.Close()
+
+	apiHandler := mockapi.NewHandler(t)
+	apiServer := httptest.NewServer(apiHandler)
+	defer apiServer.Close()
+
+	projectID := mockapi.ProjectID()
+	apiHandler.SetProjects([]*mockapi.Project{
+		{
+			ID: projectID,
+			Links: mockapi.MakeHALLinks(
+				"self=/projects/"+projectID,
+				"environments=/projects/"+projectID+"/environments",
+			),
+			DefaultBranch: "main",
+		},
+	})
+	main := makeEnv(projectID, "main", "production", "active", nil)
+	main.Links["#activities"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/activities"}
+	main.Links["#deploy"] = mockapi.HALLink{HREF: "/projects/" + projectID + "/environments/main/deploy"}
+	apiHandler.SetEnvironments([]*mockapi.Environment{main})
+
+	f := newCommandFactory(t, apiServer.URL, authServer.URL)
+	f.Run("cc")
+
+	assertTrimmed(t, `Nothing to deploy`, f.Run("env:deploy", "-p", projectID, "-e", "main"))
+
+	created, _ := time.Parse(time.RFC3339, "2014-04-01T10:00:00Z")
+	updated, _ := time.Parse(time.RFC3339, "2014-04-01T11:00:00Z")
+	apiHandler.SetProjectActivities(projectID, []*mockapi.Activity{
+		{
+			ID:                "act1",
+			Type:              "environment.push",
+			State:             "staged",
+			Result:            "success",
+			CompletionPercent: 100,
+			Project:           projectID,
+			Environments:      []string{"main"},
+			Description:       "<user>Mock User</user> pushed to <environment>main</environment>",
+			Text:              "Mock User pushed to main",
+			CreatedAt:         created,
+			UpdatedAt:         updated,
+		}, {
+			ID:                "act2",
+			Type:              "environment.variable.create",
+			State:             "staged",
+			Result:            "success",
+			CompletionPercent: 100,
+			Project:           projectID,
+			Environments:      []string{"main"},
+			Description:       "<user>Mock User</user> created variable <variable>X</variable> on environment <environment>main</environment>",
+			Text:              "Mock User created variable X on environment main",
+			CreatedAt:         created,
+			UpdatedAt:         updated,
+		},
+	})
+
+	assertTrimmed(t, `
+You are about to deploy the following changes on the environment main:
++------+-------------------------+---------------------------------------------+-----------------------------+---------+
+| ID   | Created                 | Description                                 | Type                        | Result  |
++------+-------------------------+---------------------------------------------+-----------------------------+---------+
+| act1 | 2014-04-01T10:00:00+00: | Mock User pushed to main                    | environment.push            | success |
+|      | 00                      |                                             |                             |         |
+| act2 | 2014-04-01T10:00:00+00: | Mock User created variable X on environment | environment.variable.create | success |
+|      | 00                      | main                                        |                             |         |
++------+-------------------------+---------------------------------------------+-----------------------------+---------+
+`, f.Run("env:deploy", "-p", projectID, "-e", "main"))
+}

--- a/go-tests/go.mod
+++ b/go-tests/go.mod
@@ -2,6 +2,8 @@ module github.com/platformsh/legacy-cli/tests
 
 go 1.24
 
+replace github.com/platformsh/cli => github.com/vitolkachova/cli v0.0.0-20250418083554-ba85160fb1ff
+
 require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/platformsh/cli v0.0.0-20250512110214-68e4962f0990

--- a/go-tests/go.mod
+++ b/go-tests/go.mod
@@ -2,8 +2,6 @@ module github.com/platformsh/legacy-cli/tests
 
 go 1.24
 
-replace github.com/platformsh/cli => github.com/vitolkachova/cli v0.0.0-20250418083554-ba85160fb1ff
-
 require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/platformsh/cli v0.0.0-20250512110214-68e4962f0990

--- a/src/Application.php
+++ b/src/Application.php
@@ -147,6 +147,7 @@ class Application extends ParentApplication
         $commands[] = new Command\Environment\EnvironmentCheckoutCommand();
         $commands[] = new Command\Environment\EnvironmentCurlCommand();
         $commands[] = new Command\Environment\EnvironmentDeleteCommand();
+        $commands[] = new Command\Environment\EnvironmentDeployCommand();
         $commands[] = new Command\Environment\EnvironmentDrushCommand();
         $commands[] = new Command\Environment\EnvironmentHttpAccessCommand();
         $commands[] = new Command\Environment\EnvironmentListCommand();

--- a/src/Command/Activity/ActivityCommandBase.php
+++ b/src/Command/Activity/ActivityCommandBase.php
@@ -16,7 +16,7 @@ class ActivityCommandBase extends CommandBase implements CompletionAwareInterfac
             case 'exclude-type':
                 return ActivityLoader::getAvailableTypes();
             case 'state':
-                return ['in_progress', 'pending', 'complete', 'cancelled'];
+                return ['in_progress', 'pending', 'complete', 'cancelled', 'staged'];
             case 'result':
                 return ['success', 'failure'];
         }

--- a/src/Command/Environment/EnvironmentDeployCommand.php
+++ b/src/Command/Environment/EnvironmentDeployCommand.php
@@ -1,0 +1,95 @@
+<?php
+namespace Platformsh\Cli\Command\Environment;
+
+use Platformsh\Cli\Command\CommandBase;
+use Platformsh\Cli\Console\AdaptiveTableCell;
+use Platformsh\Cli\Service\ActivityMonitor;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnvironmentDeployCommand extends CommandBase
+{
+    private $tableHeader = [
+        'id' => 'ID',
+        'created' => 'Created',
+        'description' => 'Description',
+        'type' => 'Type',
+        'result' => 'Result',
+    ];
+
+    protected function configure()
+    {
+        $this
+            ->setName('environment:deploy')
+            ->setAliases(['deploy'])
+            ->setDescription('Deploy an environment');
+        $this->addProjectOption()
+            ->addEnvironmentOption();
+        $this->addWaitOptions();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->chooseEnvFilter = $this->filterEnvsByStatus(['active', 'paused']);
+        $this->validateInput($input);
+
+        $environment = $this->getSelectedEnvironment();
+
+        if (!$environment->operationAvailable('deploy', true)) {
+            $this->stdErr->writeln(
+                "Operation not available: The environment " . $this->api()->getEnvironmentLabel($environment, 'error') . " can't be deployed."
+            );
+
+            if (!$environment->isActive()) {
+                $this->stdErr->writeln('The environment is not active.');
+            }
+
+            return 1;
+        }
+
+        $activities = $environment->getActivities(0, null, null, "staged"); //TODO: set to Activity::STATE_CANCELLED
+        if (count($activities) < 1) {
+            $output->writeln("Nothing to deploy");
+            return 0;
+        }
+
+        /** @var \Platformsh\Cli\Service\Table $table */
+        $table = $this->getService('table');
+        /** @var \Platformsh\Cli\Service\PropertyFormatter $formatter */
+        $formatter = $this->getService('property_formatter');
+
+        $rows = [];
+        foreach ($activities as $activity) {
+            $row = [
+                'id' => new AdaptiveTableCell($activity->id, ['wrap' => false]),
+                'created' => $formatter->format($activity['created_at'], 'created_at'),
+                'description' => ActivityMonitor::getFormattedDescription($activity, !$table->formatIsMachineReadable()),
+                'type' => new AdaptiveTableCell($activity->type, ['wrap' => false]),
+                'result' => ActivityMonitor::formatResult($activity->result, !$table->formatIsMachineReadable()),
+            ];
+            $rows[] = $row;
+        }
+
+        $output->writeln('You are about to deploy the following changes on the environment <comment>' . $environment->id . '</comment>:');
+        $table->render($rows, $this->tableHeader);
+
+        /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
+        $questionHelper = $this->getService('question_helper');
+        if (!$questionHelper->confirm('Continue?')) {
+            return 1;
+        }
+
+        $result = $environment->runOperation('deploy');
+
+        if ($this->shouldWait($input)) {
+            /** @var \Platformsh\Cli\Service\ActivityMonitor $activityMonitor */
+            $activityMonitor = $this->getService('activity_monitor');
+            $success = $activityMonitor->waitMultiple($result->getActivities(), $this->getSelectedProject());
+            if (!$success) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Environment/EnvironmentDeployCommand.php
+++ b/src/Command/Environment/EnvironmentDeployCommand.php
@@ -47,7 +47,7 @@ class EnvironmentDeployCommand extends CommandBase
             return 1;
         }
 
-        $activities = $environment->getActivities(0, null, null, "staged"); //TODO: set to Activity::STATE_CANCELLED
+        $activities = $environment->getActivities(0, null, null, "staged"); //TODO: set to Activity::STATE_STAGED
         if (count($activities) < 1) {
             $output->writeln("Nothing to deploy");
             return 0;

--- a/src/Command/Environment/EnvironmentDeployCommand.php
+++ b/src/Command/Environment/EnvironmentDeployCommand.php
@@ -23,7 +23,7 @@ class EnvironmentDeployCommand extends CommandBase
         $this
             ->setName('environment:deploy')
             ->setAliases(['deploy'])
-            ->setDescription('Deploy an environment');
+            ->setDescription('Deploy an environment\'s staged changes');
         $this->addProjectOption()
             ->addEnvironmentOption();
         $this->addWaitOptions();
@@ -50,7 +50,10 @@ class EnvironmentDeployCommand extends CommandBase
 
         $activities = $environment->getActivities(0, null, null, Activity::STATE_STAGED);
         if (count($activities) < 1) {
-            $output->writeln("Nothing to deploy");
+            $this->stdErr->writeln(sprintf(
+                'The environment %s has no staged changes to deploy.',
+                $this->api()->getEnvironmentLabel($environment, 'comment')
+            ));
             return 0;
         }
 
@@ -71,12 +74,14 @@ class EnvironmentDeployCommand extends CommandBase
             $rows[] = $row;
         }
 
-        $output->writeln('You are about to deploy the following changes on the environment <comment>' . $environment->id . '</comment>:');
+        $this->stdErr->writeln(sprintf('The following changes will be deployed to the environment %s:',
+            $this->api()->getEnvironmentLabel($environment, 'comment')
+        ));
         $table->render($rows, $this->tableHeader);
 
         /** @var \Platformsh\Cli\Service\QuestionHelper $questionHelper */
         $questionHelper = $this->getService('question_helper');
-        if (!$questionHelper->confirm('Continue?')) {
+        if (!$questionHelper->confirm('Are you sure you want to continue?')) {
             return 1;
         }
 

--- a/src/Command/Environment/EnvironmentDeployCommand.php
+++ b/src/Command/Environment/EnvironmentDeployCommand.php
@@ -4,6 +4,7 @@ namespace Platformsh\Cli\Command\Environment;
 use Platformsh\Cli\Command\CommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Service\ActivityMonitor;
+use Platformsh\Client\Model\Activity;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -47,7 +48,7 @@ class EnvironmentDeployCommand extends CommandBase
             return 1;
         }
 
-        $activities = $environment->getActivities(0, null, null, "staged"); //TODO: set to Activity::STATE_STAGED
+        $activities = $environment->getActivities(0, null, null, Activity::STATE_STAGED);
         if (count($activities) < 1) {
             $output->writeln("Nothing to deploy");
             return 0;

--- a/src/Service/ActivityLoader.php
+++ b/src/Service/ActivityLoader.php
@@ -177,6 +177,7 @@ class ActivityLoader
             'environment.cron',
             'environment.deactivate',
             'environment.delete',
+            'environment.deploy',
             'environment.domain.create',
             'environment.domain.delete',
             'environment.domain.update',

--- a/src/Service/ActivityMonitor.php
+++ b/src/Service/ActivityMonitor.php
@@ -525,24 +525,27 @@ class ActivityMonitor
         switch ($activity->result) {
             case Activity::RESULT_SUCCESS:
                 $stdErr->writeln('The activity succeeded: ' . self::getFormattedDescription($activity, true, true, 'green'));
-                return true;
 
             case Activity::RESULT_FAILURE:
                 if ($activity->state === Activity::STATE_CANCELLED) {
                     $stdErr->writeln('The activity was cancelled: ' . self::getFormattedDescription($activity, true, true, 'yellow'));
-                    return false;
                 }
                 $stdErr->writeln('The activity failed: ' . self::getFormattedDescription($activity, true, true, 'red'));
                 if ($logOnFailure) {
                     $stdErr->writeln('  <error>Log:</error>');
                     $stdErr->writeln($this->indent($this->formatLog($activity->readLog())));
                 }
-                return false;
 
             default:
                 $stdErr->writeln('The activity finished with an unknown result: ' . self::getFormattedDescription($activity, true, true, 'yellow'));
-                return false;
         }
+
+        if ($activity->state === Activity::STATE_STAGED) {
+            $stdErr->writeln(sprintf('To deploy staged changes, run: <info>%s deploy</info>',
+                $this->config->get('application.executable')));
+        }
+
+        return true;
     }
 
     /**

--- a/src/Service/ActivityMonitor.php
+++ b/src/Service/ActivityMonitor.php
@@ -121,7 +121,8 @@ class ActivityMonitor
 
             // Exit the loop if the log finished and the activity is complete.
             if ($seal) {
-                if ($activity->isComplete() || $activity->state === Activity::STATE_CANCELLED) {
+                if ($activity->isComplete() || $activity->state === Activity::STATE_CANCELLED
+                    || $activity->state === Activity::STATE_STAGED) {
                     break;
                 }
                 continue;


### PR DESCRIPTION
* [x] add `deploy` command
* [ ] ~~reflect auto deploy status on `env:info`~~ automatic deployments is an environment setting, while env:info deals with normal properties
* [ ] ~~rework `redeployWarning()`~~ legacy code, to be dealt with in a separated PR
* [x] add const to PHP client (https://github.com/platformsh/platformsh-client-php/pull/92)
* [x] add deploy endpoint to API mock (https://github.com/platformsh/cli/pull/244)