### PR TITLE
Increase the default limits for finding activities

### DIFF
--- a/go-tests/activity_list_test.go
+++ b/go-tests/activity_list_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -87,4 +88,51 @@ func TestActivityList(t *testing.T) {
 
 	assertTrimmed(t, "complete", f.Run("act:get", "-p", projectID, "-e", ".", "act1", "-P", "state"))
 	assertTrimmed(t, "2014-04-01T10:00:00+00:00", f.Run("act:get", "-p", projectID, "-e", ".", "act1", "-P", "created_at"))
+
+	// Generate a longer list of activities.
+	var activities = make([]*mockapi.Activity, 30)
+	for i := range activities {
+		num := i + 1
+		createdAt := aprilFoolsDay10am.Add(time.Duration(i) * time.Minute)
+		varName := "X" + strconv.Itoa(num)
+		activities[i] = &mockapi.Activity{
+			ID:                "act" + strconv.Itoa(num),
+			Type:              "environment.variable.create",
+			State:             "complete",
+			Result:            "success",
+			CompletionPercent: 100,
+			Project:           projectID,
+			Environments:      []string{"main"},
+			Description:       "<user>Mock User</user> created variable <variable>" + varName + "</variable> on environment <environment>main</environment>",
+			Text:              "Mock User created variable " + varName + " on environment main",
+			CreatedAt:         createdAt,
+			UpdatedAt:         createdAt,
+		}
+	}
+	apiHandler.SetProjectActivities(projectID, activities)
+
+	assertTrimmed(t, `
+ID	Created	Description	Progress	State	Result
+act30	2014-04-01T10:29:00+00:00	Mock User created variable X30 on environment main	100%	complete	success
+act29	2014-04-01T10:28:00+00:00	Mock User created variable X29 on environment main	100%	complete	success
+act28	2014-04-01T10:27:00+00:00	Mock User created variable X28 on environment main	100%	complete	success
+act27	2014-04-01T10:26:00+00:00	Mock User created variable X27 on environment main	100%	complete	success
+act26	2014-04-01T10:25:00+00:00	Mock User created variable X26 on environment main	100%	complete	success`,
+		f.Run("act", "-p", projectID, "-e", ".", "--format", "plain", "--limit", "5"))
+
+	assertTrimmed(t, `
+ID	Created	Description	Progress	State	Result
+act30	2014-04-01T10:29:00+00:00	Mock User created variable X30 on environment main	100%	complete	success
+act29	2014-04-01T10:28:00+00:00	Mock User created variable X29 on environment main	100%	complete	success
+act28	2014-04-01T10:27:00+00:00	Mock User created variable X28 on environment main	100%	complete	success
+act27	2014-04-01T10:26:00+00:00	Mock User created variable X27 on environment main	100%	complete	success
+act26	2014-04-01T10:25:00+00:00	Mock User created variable X26 on environment main	100%	complete	success
+act25	2014-04-01T10:24:00+00:00	Mock User created variable X25 on environment main	100%	complete	success
+act24	2014-04-01T10:23:00+00:00	Mock User created variable X24 on environment main	100%	complete	success
+act23	2014-04-01T10:22:00+00:00	Mock User created variable X23 on environment main	100%	complete	success
+act22	2014-04-01T10:21:00+00:00	Mock User created variable X22 on environment main	100%	complete	success
+act21	2014-04-01T10:20:00+00:00	Mock User created variable X21 on environment main	100%	complete	success
+act20	2014-04-01T10:19:00+00:00	Mock User created variable X20 on environment main	100%	complete	success
+act19	2014-04-01T10:18:00+00:00	Mock User created variable X19 on environment main	100%	complete	success`,
+		f.Run("act", "-p", projectID, "-e", ".", "--format", "plain", "--limit", "12"))
 }

--- a/src/Command/Activity/ActivityCancelCommand.php
+++ b/src/Command/Activity/ActivityCancelCommand.php
@@ -59,7 +59,7 @@ class ActivityCancelCommand extends ActivityCommandBase
             $activity = $this->getSelectedProject()
                 ->getActivity($id);
             if (!$activity) {
-                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, 10, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel') ?: [], 'Activity');
+                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, self::DEFAULT_FIND_LIMIT, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel') ?: [], 'Activity');
                 if (!$activity) {
                     $this->stdErr->writeln("Activity not found: <error>$id</error>");
 
@@ -67,7 +67,7 @@ class ActivityCancelCommand extends ActivityCommandBase
                 }
             }
         } else {
-            $activities = $loader->loadFromInput($apiResource, $input, 10, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel');
+            $activities = $loader->loadFromInput($apiResource, $input, self::DEFAULT_FIND_LIMIT, [Activity::STATE_PENDING, Activity::STATE_IN_PROGRESS], 'cancel');
             if (\count($activities) === 0) {
                 $this->stdErr->writeln('No cancellable activities found');
 

--- a/src/Command/Activity/ActivityCommandBase.php
+++ b/src/Command/Activity/ActivityCommandBase.php
@@ -9,6 +9,9 @@ use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 
 class ActivityCommandBase extends CommandBase implements CompletionAwareInterface
 {
+    const DEFAULT_LIST_LIMIT = 10; // Display a digestible number of activities by default.
+    const DEFAULT_FIND_LIMIT = 25; // This is the current limit per page of results.
+
     public function completeOptionValues($optionName, CompletionContext $context)
     {
         switch ($optionName) {

--- a/src/Command/Activity/ActivityGetCommand.php
+++ b/src/Command/Activity/ActivityGetCommand.php
@@ -66,7 +66,7 @@ class ActivityGetCommand extends ActivityCommandBase
             $activity = $this->getSelectedProject()
                 ->getActivity($id);
             if (!$activity) {
-                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, 10) ?: [], 'Activity');
+                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, self::DEFAULT_FIND_LIMIT) ?: [], 'Activity');
                 if (!$activity) {
                     $this->stdErr->writeln("Activity not found: <error>$id</error>");
 

--- a/src/Command/Activity/ActivityListCommand.php
+++ b/src/Command/Activity/ActivityListCommand.php
@@ -56,7 +56,7 @@ class ActivityListCommand extends ActivityCommandBase
             . "\nThe % or * characters can be used as a wildcard to exclude types."
         );
 
-        $this->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', 10)
+        $this->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', self::DEFAULT_LIST_LIMIT)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only activities created before this date will be listed')
             ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state: in_progress, pending, complete, or cancelled.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result: success or failure')
@@ -151,7 +151,8 @@ class ActivityListCommand extends ActivityCommandBase
         if (!$table->formatIsMachineReadable()) {
             $executable = $this->config()->get('application.executable');
 
-            $max = $input->getOption('limit') ? (int) $input->getOption('limit') : 10;
+            // TODO make this more deterministic by fetching limit+1 activities
+            $max = ((int) $input->getOption('limit') ?: self::DEFAULT_LIST_LIMIT);
             $maybeMoreAvailable = count($activities) === $max;
             if ($maybeMoreAvailable) {
                 $this->stdErr->writeln('');

--- a/src/Command/Activity/ActivityLogCommand.php
+++ b/src/Command/Activity/ActivityLogCommand.php
@@ -71,7 +71,7 @@ class ActivityLogCommand extends ActivityCommandBase
             $activity = $this->getSelectedProject()
                 ->getActivity($id);
             if (!$activity) {
-                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, 10) ?: [], 'Activity');
+                $activity = $this->api()->matchPartialId($id, $loader->loadFromInput($apiResource, $input, self::DEFAULT_FIND_LIMIT) ?: [], 'Activity');
                 if (!$activity) {
                     $this->stdErr->writeln("Activity not found: <error>$id</error>");
 

--- a/src/Command/Integration/Activity/IntegrationActivityListCommand.php
+++ b/src/Command/Integration/Activity/IntegrationActivityListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Platformsh\Cli\Command\Integration\Activity;
 
+use Platformsh\Cli\Command\Activity\ActivityCommandBase;
 use Platformsh\Cli\Command\Integration\IntegrationCommandBase;
 use Platformsh\Cli\Console\AdaptiveTableCell;
 use Platformsh\Cli\Console\ArrayArgument;
@@ -50,7 +51,7 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
                 . "\n" . ArrayArgument::SPLIT_HELP
                 . "\nThe % or * characters can be used as a wildcard to exclude types."
             )
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', 10)
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limit the number of results displayed', ActivityCommandBase::DEFAULT_LIST_LIMIT)
             ->addOption('start', null, InputOption::VALUE_REQUIRED, 'Only activities created before this date will be listed')
             ->addOption('state', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter activities by state.' . "\n" . ArrayArgument::SPLIT_HELP)
             ->addOption('result', null, InputOption::VALUE_REQUIRED, 'Filter activities by result')
@@ -123,7 +124,7 @@ class IntegrationActivityListCommand extends IntegrationCommandBase
         if (!$table->formatIsMachineReadable()) {
             $executable = $this->config()->get('application.executable');
 
-            $max = $input->getOption('limit') ? (int) $input->getOption('limit') : 10;
+            $max = $input->getOption('limit') ? (int) $input->getOption('limit') : ActivityCommandBase::DEFAULT_LIST_LIMIT;
             $maybeMoreAvailable = count($activities) === $max;
             if ($maybeMoreAvailable) {
                 $this->stdErr->writeln('');


### PR DESCRIPTION
Various defaults were based on the assumption that the API returns 10 activities per page. It's now 25, so the defaults can be increased. This also refactors slightly to reduce the number of harcoded values and adds a basic test for `--limit` on the activity list.