### PR TITLE
Add read-only "automatic_deployments" to env:info

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "guzzlehttp/guzzle": "^5.3",
         "guzzlehttp/ringphp": "^1.1",
         "platformsh/console-form": ">=0.0.37 <2.0",
-        "platformsh/client": ">=0.87.0 <2.0",
+        "platformsh/client": "1.x-dev",
         "symfony/console": "^3.0 >=3.2",
         "symfony/yaml": "^3.0 || ^2.6",
         "symfony/finder": "^3.0",
@@ -27,6 +27,12 @@
         "symfony/polyfill-mbstring": "^1.19",
         "symfony/polyfill-iconv": "^1.19"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/vitolkachova/platformsh-client-php"
+        }
+    ],
     "suggest": {
         "drush/drush": "For Drupal projects"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9aa7432a5a81e5e0ca9114a9c76dd675",
+    "content-hash": "7c143bed9dae901c9441c63d3dca1f2c",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -921,16 +921,16 @@
         },
         {
             "name": "platformsh/client",
-            "version": "0.88.0",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/platformsh/platformsh-client-php.git",
-                "reference": "5bd737d40743d97ab1883d6a6e762abddaa7b121"
+                "url": "https://github.com/vitolkachova/platformsh-client-php.git",
+                "reference": "293dbc7e4153fdba38003a9580b1af90880eb27e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/platformsh/platformsh-client-php/zipball/5bd737d40743d97ab1883d6a6e762abddaa7b121",
-                "reference": "5bd737d40743d97ab1883d6a6e762abddaa7b121",
+                "url": "https://api.github.com/repos/vitolkachova/platformsh-client-php/zipball/293dbc7e4153fdba38003a9580b1af90880eb27e",
+                "reference": "293dbc7e4153fdba38003a9580b1af90880eb27e",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +950,11 @@
                     "Platformsh\\Client\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Platformsh\\Client\\Tests\\": "tests"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -961,10 +965,9 @@
             ],
             "description": "Platform.sh API client",
             "support": {
-                "issues": "https://github.com/platformsh/platformsh-client-php/issues",
-                "source": "https://github.com/platformsh/platformsh-client-php/tree/0.88.0"
+                "source": "https://github.com/vitolkachova/platformsh-client-php/tree/1.x"
             },
-            "time": "2025-05-14T14:08:57+00:00"
+            "time": "2025-06-12T14:34:55+00:00"
         },
         {
             "name": "platformsh/console-form",
@@ -4060,7 +4063,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "platformsh/client": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Command/Environment/EnvironmentInfoCommand.php
+++ b/src/Command/Environment/EnvironmentInfoCommand.php
@@ -92,6 +92,10 @@ class EnvironmentInfoCommand extends CommandBase
             $headings[] = new AdaptiveTableCell($key, ['wrap' => false]);
             $values[] = $this->formatter->format($value, $key);
         }
+
+        $headings[] = 'automatic_deployments';
+        $values[] = $environment->getSettings()->explicit_deployments_enabled ? 'false' : 'true';
+
         /** @var \Platformsh\Cli\Service\Table $table */
         $table = $this->getService('table');
         $table->renderSimple($values, $headings);


### PR DESCRIPTION
Add information about deployments mode to `environment:info` command. Read-only property (feel free to say it makes zero sense).
Drafted because referencing my fork of php-client lib.