### PR TITLE
Remove "deploy" alias from env:deploy command

### DIFF
--- a/src/Command/Environment/EnvironmentDeployCommand.php
+++ b/src/Command/Environment/EnvironmentDeployCommand.php
@@ -22,7 +22,6 @@ class EnvironmentDeployCommand extends CommandBase
     {
         $this
             ->setName('environment:deploy')
-            ->setAliases(['deploy'])
             ->setDescription('Deploy an environment\'s staged changes');
         $this->addProjectOption()
             ->addEnvironmentOption();


### PR DESCRIPTION
The `deploy` alias conflicts slightly with an old idea, that `deploy` should be an alias of `push`.

The new command does "deploy staged changes", which is clearly a deploy action, whereas pushing is not (and was never) necessarily about deploying. So I think it's decent naming.

But there is a potential risk of confusion / "wtf", and I'd like to be conservative with the new feature.

- [x] ensure the suggested command in Docs does not use the alias
- [x] and the same for Console