### PR TITLE
fix: Clarify why certain functions are not available for upsun fixed

### DIFF
--- a/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -34,8 +34,8 @@ class BuildResourcesGetCommand extends ResourcesCommandBase
             $this->stdErr->writeln(
                     sprintf(
                         'The flexible resources API is not enabled for the project %s.\n
-                        The function you attempted to use is not available on upsun fixed (platformsh).\n
-                        Please refer to the Upsun fixed (platformsh) documentation: https://fixed.docs.upsun.com/ 
+                        The function you attempted to use is not available on fixed plans.\n
+                        Please refer to the Fixed documentation: https://fixed.docs.upsun.com/ 
                         ', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')
                     )
             );

--- a/src/Command/Resources/Build/BuildResourcesGetCommand.php
+++ b/src/Command/Resources/Build/BuildResourcesGetCommand.php
@@ -31,7 +31,14 @@ class BuildResourcesGetCommand extends ResourcesCommandBase
     {
         $this->validateInput($input);
         if (!$this->api()->supportsSizingApi($this->getSelectedProject())) {
-            $this->stdErr->writeln(sprintf('The flexible resources API is not enabled for the project %s.', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')));
+            $this->stdErr->writeln(
+                    sprintf(
+                        'The flexible resources API is not enabled for the project %s.\n
+                        The function you attempted to use is not available on upsun fixed (platformsh).\n
+                        Please refer to the Upsun fixed (platformsh) documentation: https://fixed.docs.upsun.com/ 
+                        ', $this->api()->getProjectLabel($this->getSelectedProject(), 'comment')
+                    )
+            );
             return 1;
         }
 


### PR DESCRIPTION
We had a customer ask to enable `flexibile resources API` on an upsun fixed project. 

This is not possible nor something we want to support, but if you look at the error message, it made sense that the customer asked for it. 

- Customer got an out of disk space warning.
- Went to docs.upsun.com 
- And then tried the command that was suggested to them

```
upsun resources:size:list -p vkp53d2mvpmig -e main
The flexible resources API is not enabled for the project SCJ Unified Website (vkp53d2mvpmig).
```

We need to clarify such errors to avoid this. 

Additionally we could improve documentation about this, but that's out of scope for this ticket. 